### PR TITLE
feat(mission-editor): add directional connections

### DIFF
--- a/Text Adventure Card Web Game/README.md
+++ b/Text Adventure Card Web Game/README.md
@@ -17,7 +17,7 @@ Text Adventure Card Web Game/
 
 ### mission-editor
 
-This folder contains a Vite + React application that provides a mission node graph editor.  It allows you to import/export JSON missions, edit rooms and nodes, visualize mission flow as a node graph and run basic validation.  See the `mission-editor/README.md` for details on running and developing the editor.
+This folder contains a Vite + React application that provides a mission node graph editor.  It allows you to import/export JSON missions, edit rooms and nodes, visualize mission flow as a node graph with directional connections, and run basic validation.  See the `mission-editor/README.md` for details on running and developing the editor.
 
 ### game-client
 

--- a/Text Adventure Card Web Game/mission-editor/README.md
+++ b/Text Adventure Card Web Game/mission-editor/README.md
@@ -18,7 +18,7 @@ The editor will launch on `http://localhost:3000` by default.
 * **Load a mission**: On first launch the editor shows an empty state.  Click **Load Sample Mission** to load the provided example or paste your own JSON into the import panel.
 * **Rooms panel**: Create new rooms, select a room to edit its details and exits, and specify which nodes appear automatically when the room is entered.
 * **Node palette**: Add new nodes of various types (scene, npc, battle, etc.) to the selected room.
-* **Graph canvas**: Visualize and lay out your story graph.  Nodes are grouped by room horizontally.  Click a node to edit it in the inspector.  Connections are drawn based on `reveal_node` outcomes on choices.
+* **Graph canvas**: Visualize and lay out your story graph.  Nodes are grouped by room horizontally.  Click a node to edit it in the inspector.  Directional connections with arrows show how a mission flows from the start node through to any end nodes, based on `reveal_node` outcomes on choices.
 * **Inspector**: Edit properties of the selected node, including its title, text, entry conditions and choices.  Conditions and outcomes are edited as raw JSON arrays for flexibility.
 * **Validation panel**: See a list of validation issues in real time, such as unreachable rooms or nodes missing outcomes.
 * **Playtest**: Use the button in the footer to highlight unreachable nodes.  Further playtest functionality can be added later.

--- a/Text Adventure Card Web Game/mission-editor/src/components/Graph.jsx
+++ b/Text Adventure Card Web Game/mission-editor/src/components/Graph.jsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useCallback } from 'react';
-import ReactFlow, { Controls, Background } from 'reactflow';
+import ReactFlow, { Controls, Background, MarkerType } from 'reactflow';
 import { validateMission } from '../lib/validate.js';
 import CustomNode from './CustomNode.jsx';
 
@@ -48,7 +48,12 @@ export default function Graph({ mission, selectedNodeId, onSelectNode, highlight
 
     // Build edges from outcomes referencing reveal_node
     const addEdge = (sourceId, targetId, handleId = null) => {
-      const edge = { id: `${sourceId}-${targetId}-${edges.length}`, source: sourceId, target: targetId };
+      const edge = {
+        id: `${sourceId}-${targetId}-${edges.length}`,
+        source: sourceId,
+        target: targetId,
+        markerEnd: { type: MarkerType.ArrowClosed },
+      };
       if (handleId) edge.sourceHandle = handleId;
       edges.push(edge);
     };


### PR DESCRIPTION
## Summary
- draw arrowed connections between mission nodes to clarify flow
- document directional graph connections in README files

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ad34073b48333867764bf82826390