### PR TITLE
feat(editor): add structured condition and outcome editors

### DIFF
--- a/Text Adventure Card Web Game/mission-editor/src/components/ConditionsEditor.jsx
+++ b/Text Adventure Card Web Game/mission-editor/src/components/ConditionsEditor.jsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { REQUIREMENT_TYPES, STAT_NAMES } from '../lib/schema.js';
+
+/**
+ * Editor for an array of entry conditions.
+ * @param {{conditions: Array, onChange: Function}} props
+ */
+export default function ConditionsEditor({ conditions, onChange }) {
+  const update = (idx, field, value) => {
+    const copy = [...conditions];
+    copy[idx] = { ...copy[idx], [field]: value };
+    onChange(copy);
+  };
+
+  const updateType = (idx, type) => {
+    const copy = [...conditions];
+    copy[idx] = { type };
+    onChange(copy);
+  };
+
+  const addCondition = () => {
+    onChange([...conditions, { type: REQUIREMENT_TYPES[0] }]);
+  };
+
+  const removeCondition = (idx) => {
+    onChange(conditions.filter((_, i) => i !== idx));
+  };
+
+  const renderFields = (cond, idx) => {
+    switch (cond.type) {
+      case 'stat_at_least':
+        return (
+          <>
+            <select value={cond.stat || STAT_NAMES[0]} onChange={(e) => update(idx, 'stat', e.target.value)}>
+              {STAT_NAMES.map((s) => (
+                <option key={s} value={s}>{s}</option>
+              ))}
+            </select>
+            <input
+              type="number"
+              value={cond.value ?? 0}
+              onChange={(e) => update(idx, 'value', Number(e.target.value))}
+            />
+          </>
+        );
+      default:
+        return (
+          <input
+            type="text"
+            value={cond.value || ''}
+            onChange={(e) => update(idx, 'value', e.target.value)}
+          />
+        );
+    }
+  };
+
+  return (
+    <div className="conditions-editor">
+      {conditions.map((cond, idx) => (
+        <div key={idx} className="condition-row">
+          <select value={cond.type} onChange={(e) => updateType(idx, e.target.value)}>
+            {REQUIREMENT_TYPES.map((t) => (
+              <option key={t} value={t}>{t}</option>
+            ))}
+          </select>
+          {renderFields(cond, idx)}
+          <button type="button" onClick={() => removeCondition(idx)}>Delete</button>
+        </div>
+      ))}
+      <button type="button" onClick={addCondition}>Add Condition</button>
+    </div>
+  );
+}

--- a/Text Adventure Card Web Game/mission-editor/src/components/NodeInspector.jsx
+++ b/Text Adventure Card Web Game/mission-editor/src/components/NodeInspector.jsx
@@ -1,30 +1,27 @@
 import React, { useState, useEffect } from 'react';
 import { NODE_TYPES } from '../lib/schema.js';
+import ConditionsEditor from './ConditionsEditor.jsx';
+import OutcomesEditor from './OutcomesEditor.jsx';
 
 /**
- * Inspector for editing a single node's fields. Works with minimal controls
- * for common fields and JSON editing for complex arrays.
- * @param {Object} props
- * @param {Object} props.mission Mission object
- * @param {string|null} props.selectedNodeId Selected node id
- * @param {Function} props.onChange Called with updater when mission changes
+ * Inspector for editing a single node's fields using structured editors
+ * for conditions and outcomes.
  */
 export default function NodeInspector({ mission, selectedNodeId, onChange }) {
   const node = mission.nodes?.find((n) => n.id === selectedNodeId);
-  const [conditionsText, setConditionsText] = useState('');
+  const [conditionsState, setConditionsState] = useState([]);
   const [choicesState, setChoicesState] = useState([]);
 
-  // Sync local state when node changes
   useEffect(() => {
     if (node) {
-      setConditionsText(JSON.stringify(node.entry_conditions || [], null, 2));
-      setChoicesState(() => {
-        return (node.choices || []).map((choice) => ({
+      setConditionsState(node.entry_conditions || []);
+      setChoicesState(
+        (node.choices || []).map((choice) => ({
           label: choice.label || '',
-          conditions: JSON.stringify(choice.entry_conditions || [], null, 2),
-          outcomes: JSON.stringify(choice.outcomes || [], null, 2),
-        }));
-      });
+          conditions: choice.entry_conditions || [],
+          outcomes: choice.outcomes || [],
+        }))
+      );
     }
   }, [node]);
 
@@ -37,7 +34,6 @@ export default function NodeInspector({ mission, selectedNodeId, onChange }) {
     );
   }
 
-  // Handle simple field updates
   const handleFieldChange = (field, value) => {
     onChange((m) => {
       const n = m.nodes.find((nd) => nd.id === node.id);
@@ -45,20 +41,11 @@ export default function NodeInspector({ mission, selectedNodeId, onChange }) {
     });
   };
 
-  // Handle entry conditions text area on blur
-  const handleConditionsBlur = () => {
-    try {
-      const parsed = JSON.parse(conditionsText);
-      onChange((m) => {
-        const n = m.nodes.find((nd) => nd.id === node.id);
-        if (n) n.entry_conditions = parsed;
-      });
-    } catch (err) {
-      console.warn('Invalid JSON for entry conditions');
-    }
+  const handleConditionsChange = (conds) => {
+    setConditionsState(conds);
+    handleFieldChange('entry_conditions', conds);
   };
 
-  // Handle choices editing
   const handleChoiceChange = (idx, field, value) => {
     setChoicesState((prev) => {
       const copy = [...prev];
@@ -71,28 +58,23 @@ export default function NodeInspector({ mission, selectedNodeId, onChange }) {
     onChange((m) => {
       const n = m.nodes.find((nd) => nd.id === node.id);
       if (n) {
-        n.choices = choicesState.map((choice) => {
-          const entry_conditions = safeParseJSON(choice.conditions, []);
-          const outcomes = safeParseJSON(choice.outcomes, []);
-          return {
-            label: choice.label,
-            entry_conditions,
-            outcomes,
-          };
-        });
+        n.choices = choicesState.map((choice) => ({
+          label: choice.label,
+          entry_conditions: choice.conditions,
+          outcomes: choice.outcomes,
+        }));
       }
     });
   };
 
   const addChoice = () => {
-    setChoicesState((prev) => [...prev, { label: '', conditions: '[]', outcomes: '[]' }]);
+    setChoicesState((prev) => [...prev, { label: '', conditions: [], outcomes: [] }]);
   };
 
   const removeChoice = (idx) => {
     setChoicesState((prev) => prev.filter((_, i) => i !== idx));
   };
 
-  // Render
   return (
     <div className="node-inspector">
       <h2>Inspector</h2>
@@ -135,11 +117,10 @@ export default function NodeInspector({ mission, selectedNodeId, onChange }) {
         />
       </label>
       <label>
-        Entry Conditions (JSON)
-        <textarea
-          value={conditionsText}
-          onChange={(e) => setConditionsText(e.target.value)}
-          onBlur={handleConditionsBlur}
+        Entry Conditions
+        <ConditionsEditor
+          conditions={conditionsState}
+          onChange={handleConditionsChange}
         />
       </label>
       <h3>Choices</h3>
@@ -155,37 +136,26 @@ export default function NodeInspector({ mission, selectedNodeId, onChange }) {
               />
             </label>
             <label>
-              Entry Conditions (JSON)
-              <textarea
-                value={choice.conditions}
-                onChange={(e) => handleChoiceChange(idx, 'conditions', e.target.value)}
-                rows={3}
+              Entry Conditions
+              <ConditionsEditor
+                conditions={choice.conditions}
+                onChange={(conds) => handleChoiceChange(idx, 'conditions', conds)}
               />
             </label>
             <label>
-              Outcomes (JSON)
-              <textarea
-                value={choice.outcomes}
-                onChange={(e) => handleChoiceChange(idx, 'outcomes', e.target.value)}
-                rows={3}
+              Outcomes
+              <OutcomesEditor
+                mission={mission}
+                outcomes={choice.outcomes}
+                onChange={(outs) => handleChoiceChange(idx, 'outcomes', outs)}
               />
             </label>
             <button onClick={() => removeChoice(idx)}>Delete Choice</button>
           </div>
         ))}
         <button onClick={addChoice}>Add Choice</button>
-        {/* Synchronize choices to mission when leaving editor area */}
         <button onClick={syncChoicesToMission}>Save Choices</button>
       </div>
     </div>
   );
-}
-
-// Helper to safely parse JSON, returning fallback on error
-function safeParseJSON(str, fallback) {
-  try {
-    return JSON.parse(str);
-  } catch {
-    return fallback;
-  }
 }

--- a/Text Adventure Card Web Game/mission-editor/src/components/OutcomesEditor.jsx
+++ b/Text Adventure Card Web Game/mission-editor/src/components/OutcomesEditor.jsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { OUTCOME_TYPES } from '../lib/schema.js';
+
+/**
+ * Editor for an array of outcomes.
+ * @param {{mission: Object, outcomes: Array, onChange: Function}} props
+ */
+export default function OutcomesEditor({ mission, outcomes, onChange }) {
+  const update = (idx, field, value) => {
+    const copy = [...outcomes];
+    copy[idx] = { ...copy[idx], [field]: value };
+    onChange(copy);
+  };
+
+  const updateType = (idx, type) => {
+    const copy = [...outcomes];
+    copy[idx] = { type };
+    onChange(copy);
+  };
+
+  const addOutcome = () => {
+    onChange([...outcomes, { type: OUTCOME_TYPES[0] }]);
+  };
+
+  const removeOutcome = (idx) => {
+    onChange(outcomes.filter((_, i) => i !== idx));
+  };
+
+  const renderFields = (outcome, idx) => {
+    switch (outcome.type) {
+      case 'move_room':
+        return (
+          <select value={outcome.room_id || ''} onChange={(e) => update(idx, 'room_id', e.target.value)}>
+            <option value="" disabled>Select room</option>
+            {mission.rooms?.map((r) => (
+              <option key={r.id} value={r.id}>{r.name || r.id}</option>
+            ))}
+          </select>
+        );
+      case 'damage_player':
+        return (
+          <input
+            type="number"
+            value={outcome.amount ?? 0}
+            onChange={(e) => update(idx, 'amount', Number(e.target.value))}
+          />
+        );
+      default:
+        return (
+          <input
+            type="text"
+            value={outcome.value || ''}
+            onChange={(e) => update(idx, 'value', e.target.value)}
+          />
+        );
+    }
+  };
+
+  return (
+    <div className="outcomes-editor">
+      {outcomes.map((outcome, idx) => (
+        <div key={idx} className="outcome-row">
+          <select value={outcome.type} onChange={(e) => updateType(idx, e.target.value)}>
+            {OUTCOME_TYPES.map((t) => (
+              <option key={t} value={t}>{t}</option>
+            ))}
+          </select>
+          {renderFields(outcome, idx)}
+          <button type="button" onClick={() => removeOutcome(idx)}>Delete</button>
+        </div>
+      ))}
+      <button type="button" onClick={addOutcome}>Add Outcome</button>
+    </div>
+  );
+}

--- a/Text Adventure Card Web Game/mission-editor/src/lib/schema.js
+++ b/Text Adventure Card Web Game/mission-editor/src/lib/schema.js
@@ -36,6 +36,7 @@ export const OUTCOME_TYPES = [
   'grant_card',
   'grant_info',
   'grant_xp',
+  'damage_player',
   'apply_status',
   'start_battle',
   'end_mission',


### PR DESCRIPTION
## Summary
- add `ConditionsEditor` and `OutcomesEditor` components with dropdowns for types and fields
- allow multiple structured outcomes including damage player and move room
- wire new editors into NodeInspector for user-friendly condition/outcome editing

## Testing
- `npm test` (fails: Missing script "test")


------
https://chatgpt.com/codex/tasks/task_e_689adb652ab88333aee1e394f75d50f6