### PR TITLE
Add room containers to mission editor graph

### DIFF
--- a/mission-editor/src/App.jsx
+++ b/mission-editor/src/App.jsx
@@ -66,6 +66,21 @@ export default function App() {
     setSelectedRoomId(defaultMission.start_room_id || null);
   };
 
+  // Create a new empty mission with one room container
+  const createNewMission = () => {
+    const firstRoomId = `room_${Date.now()}`;
+    const newMission = {
+      rooms: [
+        { id: firstRoomId, name: 'Room 1', art: '', music: '', exits: [], auto_nodes: [] },
+      ],
+      nodes: [],
+      start_room_id: firstRoomId,
+    };
+    setMission(newMission);
+    setSelectedNodeId(null);
+    setSelectedRoomId(firstRoomId);
+  };
+
   // Render empty state when no mission is loaded
   if (!mission) {
     return (
@@ -76,7 +91,8 @@ export default function App() {
         <div className="app-body" style={{ justifyContent: 'center', alignItems: 'center' }}>
           <div style={{ maxWidth: 600, padding: '16px', textAlign: 'center' }}>
             <h2>No mission loaded</h2>
-            <p>Start by loading the provided sample mission or importing your own JSON file.</p>
+            <p>Create a new mission, load the sample mission, or import an existing JSON file.</p>
+            <button onClick={createNewMission} style={{ marginBottom: '8px' }}>New Empty Mission</button>
             <button onClick={loadSample} style={{ marginBottom: '8px' }}>Load Sample Mission</button>
             <div>
               <ExportImport mission={{}} onImport={handleImport} />

--- a/mission-editor/src/components/RoomContainer.jsx
+++ b/mission-editor/src/components/RoomContainer.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+/**
+ * Visual container node representing a room. Child storylet nodes are rendered
+ * inside this container by React Flow when they reference this node as their
+ * parent. The container itself is not interactive; it simply displays the room
+ * name and a bordered box that groups its children.
+ *
+ * @param {Object} props
+ * @param {Object} props.data Node data containing label
+ */
+export default function RoomContainer({ data }) {
+  const { label } = data;
+  return (
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        boxSizing: 'border-box',
+        background: '#f5f5f5',
+        border: '2px solid #888',
+        borderRadius: 8,
+        padding: 8,
+        pointerEvents: 'none',
+      }}
+    >
+      <div
+        style={{
+          textAlign: 'center',
+          fontWeight: 'bold',
+          marginBottom: 4,
+          pointerEvents: 'none',
+        }}
+      >
+        {label}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Visualize rooms with new `RoomContainer` nodes that group storylet nodes in React Flow
- Nest storylet nodes within their room containers and register container node type
- Allow starting a new mission with an initial room and button to create empty missions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b57ff3e00833385754cb1deadf372