### PR TITLE
Add example player data and endpoint

### DIFF
--- a/assets/players/example_player.json
+++ b/assets/players/example_player.json
@@ -1,0 +1,25 @@
+{
+  "id": "example_player",
+  "profile": {
+    "name": "Aria Swiftwind",
+    "avatar": "aria.png",
+    "level": 3,
+    "xp": 750,
+    "gold": 150
+  },
+  "deck": [
+    { "id": "strike", "name": "Strike", "type": "attack", "power": 6 },
+    { "id": "defend", "name": "Defend", "type": "skill", "block": 5 },
+    { "id": "fireball", "name": "Fireball", "type": "spell", "power": 8 }
+  ],
+  "inventory": {
+    "gold": 150,
+    "items": [
+      { "id": "healing_potion", "name": "Healing Potion", "quantity": 3 },
+      { "id": "rope", "name": "Climbing Rope", "quantity": 1 }
+    ],
+    "cards": [
+      { "id": "quick_slash", "name": "Quick Slash", "type": "attack", "power": 4 }
+    ]
+  }
+}

--- a/game-client/src/App.jsx
+++ b/game-client/src/App.jsx
@@ -1,6 +1,15 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 export default function App() {
+  const [player, setPlayer] = useState(null);
+
+  useEffect(() => {
+    fetch('http://localhost:4000/players/example_player')
+      .then((res) => res.json())
+      .then(setPlayer)
+      .catch((err) => console.error('Failed to load player', err));
+  }, []);
+
   const containerStyle = {
     position: 'relative',
     minHeight: '100vh',
@@ -49,8 +58,10 @@ export default function App() {
   return (
     <div style={containerStyle}>
       <div style={profileStyle}>
-        <div style={avatarStyle}>P</div>
-        <span>Player</span>
+        <div style={avatarStyle}>
+          {player ? player.profile.name.charAt(0) : 'P'}
+        </div>
+        <span>{player ? player.profile.name : 'Player'}</span>
       </div>
 
       <h1>Main Menu</h1>
@@ -68,6 +79,25 @@ export default function App() {
           <button style={buttonStyle}>Mission Editor</button>
         </li>
       </ul>
+
+      {player && (
+        <div style={{ marginTop: 32, textAlign: 'left' }}>
+          <h2>Deck ({player.deck.length})</h2>
+          <ul>
+            {player.deck.map((card) => (
+              <li key={card.id}>{card.name}</li>
+            ))}
+          </ul>
+          <h2>Inventory</h2>
+          <ul>
+            {player.inventory.items.map((item) => (
+              <li key={item.id}>
+                {item.name} x{item.quantity}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
     </div>
   );
 }

--- a/server/README.md
+++ b/server/README.md
@@ -1,6 +1,6 @@
 # Server
 
-This directory contains a minimal Express server that can be expanded to support the Text Adventure Card Web Game.  The current implementation serves mission JSON files located in `../assets/missions` via a simple REST endpoint.
+This directory contains a minimal Express server that can be expanded to support the Text Adventure Card Web Game.  The current implementation serves mission JSON files located in `../assets/missions` and example player data located in `../assets/players` via simple REST endpoints.
 
 ## Setup
 
@@ -16,5 +16,6 @@ The server will run on `http://localhost:4000` by default.
 ## API Endpoints
 
 * `GET /missions/:missionId` – returns the mission JSON for the given `missionId`, or a 404 if not found.  For example, `GET /missions/whispering_corridors` will return `whispering_corridors.json`.
+* `GET /players/:playerId` – returns the player JSON for the given `playerId`, or a 404 if not found.  For example, `GET /players/example_player` will return `example_player.json`.
 
 You can expand this server with additional endpoints for saving progress, running game logic, authentication and more.

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -5,10 +5,11 @@ import { fileURLToPath } from 'url';
 const app = express();
 const PORT = process.env.PORT || 4000;
 
-// Serve static mission JSON files
+// Serve static mission and player JSON files
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const missionsDir = path.resolve(__dirname, '../../assets/missions');
+const playersDir = path.resolve(__dirname, '../../assets/players');
 
 app.get('/missions/:missionId', (req, res) => {
   const id = req.params.missionId;
@@ -17,6 +18,16 @@ app.get('/missions/:missionId', (req, res) => {
     res.json(json);
   } catch {
     res.status(404).json({ error: 'Mission not found' });
+  }
+});
+
+app.get('/players/:playerId', (req, res) => {
+  const id = req.params.playerId;
+  try {
+    const json = require(path.join(playersDir, `${id}.json`));
+    res.json(json);
+  } catch {
+    res.status(404).json({ error: 'Player not found' });
   }
 });
 


### PR DESCRIPTION
## Summary
- add example player profile, deck, and inventory JSON
- serve player data with new `/players/:playerId` endpoint
- load player info in client and display deck/inventory

## Testing
- `cd server && npm test`
- `cd game-client && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b582bcaec833381302f2fe98dd070