### PR TITLE
feat: add deck builder page with reusable card

### DIFF
--- a/game-client/src/App.jsx
+++ b/game-client/src/App.jsx
@@ -1,7 +1,10 @@
 import React, { useEffect, useState } from 'react';
+import MainMenu from './pages/MainMenu';
+import DeckBuilder from './pages/DeckBuilder';
 
 export default function App() {
   const [player, setPlayer] = useState(null);
+  const [view, setView] = useState('menu');
 
   useEffect(() => {
     fetch('http://localhost:4000/players/example_player')
@@ -10,95 +13,9 @@ export default function App() {
       .catch((err) => console.error('Failed to load player', err));
   }, []);
 
-  const containerStyle = {
-    position: 'relative',
-    minHeight: '100vh',
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'center',
-    justifyContent: 'center',
-    fontFamily: 'sans-serif',
-  };
+  if (view === 'deck') {
+    return <DeckBuilder player={player} onBack={() => setView('menu')} />;
+  }
 
-  const profileStyle = {
-    position: 'absolute',
-    top: 16,
-    right: 16,
-    display: 'flex',
-    alignItems: 'center',
-    gap: 8,
-  };
-
-  const avatarStyle = {
-    width: 40,
-    height: 40,
-    borderRadius: '50%',
-    background: '#ccc',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    fontWeight: 'bold',
-  };
-
-  const menuStyle = {
-    listStyle: 'none',
-    padding: 0,
-    margin: 0,
-    display: 'flex',
-    flexDirection: 'column',
-    gap: 12,
-  };
-
-  const buttonStyle = {
-    padding: '12px 24px',
-    fontSize: 16,
-    cursor: 'pointer',
-  };
-
-  return (
-    <div style={containerStyle}>
-      <div style={profileStyle}>
-        <div style={avatarStyle}>
-          {player ? player.profile.name.charAt(0) : 'P'}
-        </div>
-        <span>{player ? player.profile.name : 'Player'}</span>
-      </div>
-
-      <h1>Main Menu</h1>
-      <ul style={menuStyle}>
-        <li>
-          <button style={buttonStyle}>Mission Selection</button>
-        </li>
-        <li>
-          <button style={buttonStyle}>Deck Editor</button>
-        </li>
-        <li>
-          <button style={buttonStyle}>Inventory</button>
-        </li>
-        <li>
-          <button style={buttonStyle}>Mission Editor</button>
-        </li>
-      </ul>
-
-      {player && (
-        <div style={{ marginTop: 32, textAlign: 'left' }}>
-          <h2>Deck ({player.deck.length})</h2>
-          <ul>
-            {player.deck.map((card) => (
-              <li key={card.id}>{card.name}</li>
-            ))}
-          </ul>
-          <h2>Inventory</h2>
-          <ul>
-            {player.inventory.items.map((item) => (
-              <li key={item.id}>
-                {item.name} x{item.quantity}
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
-    </div>
-  );
+  return <MainMenu player={player} onOpenDeckBuilder={() => setView('deck')} />;
 }
-

--- a/game-client/src/components/Card.jsx
+++ b/game-client/src/components/Card.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+// Basic card template that can be reused across the project
+// Accepts a `card` object and renders its name and any additional text
+export default function Card({ card }) {
+  const containerStyle = {
+    border: '1px solid #333',
+    borderRadius: 8,
+    padding: 12,
+    width: 150,
+    background: '#fff',
+    textAlign: 'center',
+  };
+
+  const nameStyle = {
+    fontWeight: 'bold',
+    marginBottom: 8,
+  };
+
+  return (
+    <div style={containerStyle}>
+      <div style={nameStyle}>{card.name}</div>
+      {card.description && <div>{card.description}</div>}
+      {card.effect && <div>{card.effect}</div>}
+    </div>
+  );
+}

--- a/game-client/src/pages/DeckBuilder.jsx
+++ b/game-client/src/pages/DeckBuilder.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import Card from '../components/Card';
+
+export default function DeckBuilder({ player, onBack }) {
+  if (!player) {
+    return <div>Loading...</div>;
+  }
+
+  const deck = [
+    player.deck.character,
+    player.deck.weapon,
+    ...Object.values(player.deck.equipment || {}),
+    ...player.deck.accessories,
+    player.deck.utility,
+  ].filter(Boolean);
+
+  const gridStyle = {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: 16,
+  };
+
+  return (
+    <div style={{ padding: 16 }}>
+      <button onClick={onBack} style={{ marginBottom: 16 }}>
+        Back to Menu
+      </button>
+      <h1>Deck Builder</h1>
+      <div style={gridStyle}>
+        {deck.map((card) => (
+          <Card key={card.id} card={card} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/game-client/src/pages/MainMenu.jsx
+++ b/game-client/src/pages/MainMenu.jsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import Card from '../components/Card';
+
+export default function MainMenu({ player, onOpenDeckBuilder }) {
+  const containerStyle = {
+    position: 'relative',
+    minHeight: '100vh',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    fontFamily: 'sans-serif',
+  };
+
+  const profileStyle = {
+    position: 'absolute',
+    top: 16,
+    right: 16,
+    display: 'flex',
+    alignItems: 'center',
+    gap: 8,
+  };
+
+  const avatarStyle = {
+    width: 40,
+    height: 40,
+    borderRadius: '50%',
+    background: '#ccc',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    fontWeight: 'bold',
+  };
+
+  const menuStyle = {
+    listStyle: 'none',
+    padding: 0,
+    margin: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 12,
+  };
+
+  const buttonStyle = {
+    padding: '12px 24px',
+    fontSize: 16,
+    cursor: 'pointer',
+  };
+
+  if (!player) {
+    return <div style={containerStyle}>Loading...</div>;
+  }
+
+  const deck = [
+    player.deck.character,
+    player.deck.weapon,
+    ...Object.values(player.deck.equipment || {}),
+    ...player.deck.accessories,
+    player.deck.utility,
+  ].filter(Boolean);
+
+  return (
+    <div style={containerStyle}>
+      <div style={profileStyle}>
+        <div style={avatarStyle}>{player.profile.name.charAt(0)}</div>
+        <span>{player.profile.name}</span>
+      </div>
+
+      <h1>Main Menu</h1>
+      <ul style={menuStyle}>
+        <li>
+          <button style={buttonStyle}>Mission Selection</button>
+        </li>
+        <li>
+          <button style={buttonStyle} onClick={onOpenDeckBuilder}>
+            Deck Editor
+          </button>
+        </li>
+        <li>
+          <button style={buttonStyle}>Inventory</button>
+        </li>
+        <li>
+          <button style={buttonStyle}>Mission Editor</button>
+        </li>
+      </ul>
+
+      <div style={{ marginTop: 32, textAlign: 'left' }}>
+        <h2>Deck ({deck.length})</h2>
+        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+          {deck.map((card) => (
+            <Card key={card.id} card={card} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create reusable Card component for displaying cards
- add Deck Builder page using card template
- link Deck Editor menu option to deck builder view

## Testing
- `cd game-client && npm test`
- `cd server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b8b596ed083339443994c6979b8d0