### PR TITLE
feat: add router for navigation

### DIFF
--- a/game-client/package.json
+++ b/game-client/package.json
@@ -10,10 +10,11 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.30.1"
   },
   "devDependencies": {
-    "vite": "^4.5.0",
-    "@vitejs/plugin-react": "^4.1.0"
+    "@vitejs/plugin-react": "^4.1.0",
+    "vite": "^4.5.0"
   }
 }

--- a/game-client/src/App.jsx
+++ b/game-client/src/App.jsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useState } from 'react';
+import { Routes, Route } from 'react-router-dom';
 import MainMenu from './pages/MainMenu';
 import DeckBuilder from './pages/DeckBuilder';
+import MissionEditor from './pages/MissionEditor';
 
 export default function App() {
   const [player, setPlayer] = useState(null);
-  const [view, setView] = useState('menu');
 
   useEffect(() => {
     fetch('http://localhost:4000/players/example_player')
@@ -13,9 +14,11 @@ export default function App() {
       .catch((err) => console.error('Failed to load player', err));
   }, []);
 
-  if (view === 'deck') {
-    return <DeckBuilder player={player} onBack={() => setView('menu')} />;
-  }
-
-  return <MainMenu player={player} onOpenDeckBuilder={() => setView('deck')} />;
+  return (
+    <Routes>
+      <Route path="/" element={<MainMenu player={player} />} />
+      <Route path="/deck" element={<DeckBuilder player={player} />} />
+      <Route path="/mission-editor" element={<MissionEditor player={player} />} />
+    </Routes>
+  );
 }

--- a/game-client/src/main.jsx
+++ b/game-client/src/main.jsx
@@ -1,9 +1,12 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
 import App from './App.jsx';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </React.StrictMode>
 );

--- a/game-client/src/pages/DeckBuilder.jsx
+++ b/game-client/src/pages/DeckBuilder.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import Card from '../components/Card';
 
-export default function DeckBuilder({ player, onBack }) {
+export default function DeckBuilder({ player }) {
   if (!player) {
     return <div>Loading...</div>;
   }
@@ -22,9 +23,9 @@ export default function DeckBuilder({ player, onBack }) {
 
   return (
     <div style={{ padding: 16 }}>
-      <button onClick={onBack} style={{ marginBottom: 16 }}>
-        Back to Menu
-      </button>
+      <Link to="/">
+        <button style={{ marginBottom: 16 }}>Back to Menu</button>
+      </Link>
       <h1>Deck Builder</h1>
       <div style={gridStyle}>
         {deck.map((card) => (

--- a/game-client/src/pages/MainMenu.jsx
+++ b/game-client/src/pages/MainMenu.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import Card from '../components/Card';
 
-export default function MainMenu({ player, onOpenDeckBuilder }) {
+export default function MainMenu({ player }) {
   const containerStyle = {
     position: 'relative',
     minHeight: '100vh',
@@ -72,15 +73,17 @@ export default function MainMenu({ player, onOpenDeckBuilder }) {
           <button style={buttonStyle}>Mission Selection</button>
         </li>
         <li>
-          <button style={buttonStyle} onClick={onOpenDeckBuilder}>
-            Deck Editor
-          </button>
+          <Link to="/deck">
+            <button style={buttonStyle}>Deck Editor</button>
+          </Link>
         </li>
         <li>
           <button style={buttonStyle}>Inventory</button>
         </li>
         <li>
-          <button style={buttonStyle}>Mission Editor</button>
+          <Link to="/mission-editor">
+            <button style={buttonStyle}>Mission Editor</button>
+          </Link>
         </li>
       </ul>
 

--- a/game-client/src/pages/MissionEditor.jsx
+++ b/game-client/src/pages/MissionEditor.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+export default function MissionEditor() {
+  return (
+    <div style={{ padding: 16 }}>
+      <Link to="/">
+        <button style={{ marginBottom: 16 }}>Back to Menu</button>
+      </Link>
+      <h1>Mission Editor</h1>
+      <p>Mission editor content coming soon.</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- configure React Router to navigate between main menu, deck builder, and mission editor
- add mission editor placeholder page
- link pages using router Links and BrowserRouter

## Testing
- `cd game-client && npm test`
- `cd mission-editor && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b908357e483339789fdea20f6b53c