### PR TITLE
Fix loading hang and add navigation tests

### DIFF
--- a/game-client/package.json
+++ b/game-client/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "node --test"
+    "test": "vitest run"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -14,7 +14,10 @@
     "react-router-dom": "^6.30.1"
   },
   "devDependencies": {
+    "@testing-library/react": "^14.2.1",
     "@vitejs/plugin-react": "^4.1.0",
-    "vite": "^4.5.0"
+    "jsdom": "^26.1.0",
+    "vite": "^4.5.0",
+    "vitest": "^1.0.0"
   }
 }

--- a/game-client/src/App.jsx
+++ b/game-client/src/App.jsx
@@ -7,11 +7,25 @@ import MissionEditor from './pages/MissionEditor';
 export default function App() {
   const [player, setPlayer] = useState(null);
 
+  const fallbackPlayer = {
+    profile: { name: 'Test Player' },
+    deck: { character: null, weapon: null, equipment: {}, accessories: [], utility: null },
+  };
+
   useEffect(() => {
-    fetch('http://localhost:4000/players/example_player')
-      .then((res) => res.json())
-      .then(setPlayer)
-      .catch((err) => console.error('Failed to load player', err));
+    async function loadPlayer() {
+      try {
+        const res = await fetch('http://localhost:4000/players/example_player');
+        if (!res.ok) throw new Error('Network response was not ok');
+        const data = await res.json();
+        setPlayer(data);
+      } catch (err) {
+        console.error('Failed to load player', err);
+        setPlayer(fallbackPlayer);
+      }
+    }
+
+    loadPlayer();
   }, []);
 
   return (

--- a/game-client/test/basic.test.js
+++ b/game-client/test/basic.test.js
@@ -1,6 +1,0 @@
-const test = require('node:test');
-const assert = require('node:assert/strict');
-
-test('basic math works in game-client', () => {
-  assert.strictEqual(1 + 1, 2);
-});

--- a/game-client/test/navigation.test.jsx
+++ b/game-client/test/navigation.test.jsx
@@ -1,0 +1,33 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import App from '../src/App.jsx';
+
+describe('App navigation', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.reject(new Error('network error'))));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('renders menu and navigates to linked pages', async () => {
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('Main Menu')).toBeTruthy();
+
+    fireEvent.click(screen.getByText('Deck Editor'));
+    expect(await screen.findByText('Deck Builder')).toBeTruthy();
+
+    fireEvent.click(screen.getByText('Back to Menu'));
+    expect(await screen.findByText('Main Menu')).toBeTruthy();
+
+    fireEvent.click(screen.getByText('Mission Editor'));
+    expect(await screen.findByText('Mission editor content coming soon.')).toBeTruthy();
+  });
+});

--- a/game-client/vite.config.js
+++ b/game-client/vite.config.js
@@ -6,4 +6,7 @@ export default defineConfig({
   server: {
     port: 3001,
   },
+  test: {
+    environment: 'jsdom',
+  },
 });


### PR DESCRIPTION
## Summary
- prevent infinite loading by falling back to placeholder player data
- configure Vitest and add test checking menu and navigation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c263a81248333ae845b615fef1db6