### PR TITLE
feat: display equipped cards in deck slots

### DIFF
--- a/game-client/src/components/DeckDisplay.jsx
+++ b/game-client/src/components/DeckDisplay.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import Card from './Card';
+
+export default function DeckDisplay({ deck }) {
+  const gridStyle = {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: 16,
+  };
+
+  const slotStyle = {
+    width: 150,
+    textAlign: 'center',
+  };
+
+  const labelStyle = {
+    marginBottom: 8,
+    fontWeight: 'bold',
+  };
+
+  const emptyStyle = {
+    border: '1px dashed #999',
+    borderRadius: 8,
+    padding: 12,
+    height: 100,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    background: '#f9f9f9',
+  };
+
+  function renderSlot(label, card) {
+    return (
+      <div key={label} style={slotStyle}>
+        <div style={labelStyle}>{label}</div>
+        {card ? <Card card={card} /> : <div style={emptyStyle}>Empty</div>}
+      </div>
+    );
+  }
+
+  const slots = [
+    ['Character', deck.character],
+    ['Weapon', deck.weapon],
+    ['Body', deck.equipment?.body],
+    ['Gloves', deck.equipment?.gloves],
+    ['Boots', deck.equipment?.boots],
+    ['Accessory 1', deck.accessories?.[0]],
+    ['Accessory 2', deck.accessories?.[1]],
+    ['Utility', deck.utility],
+  ];
+
+  return <div style={gridStyle}>{slots.map(([label, card]) => renderSlot(label, card))}</div>;
+}

--- a/game-client/src/pages/DeckBuilder.jsx
+++ b/game-client/src/pages/DeckBuilder.jsx
@@ -1,25 +1,24 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import Card from '../components/Card';
+import DeckDisplay from '../components/DeckDisplay';
 
 export default function DeckBuilder({ player }) {
   if (!player) {
     return <div>Loading...</div>;
   }
 
-  const deck = [
+  const deckSlots = [
     player.deck.character,
     player.deck.weapon,
-    ...Object.values(player.deck.equipment || {}),
-    ...player.deck.accessories,
+    player.deck.equipment?.body,
+    player.deck.equipment?.gloves,
+    player.deck.equipment?.boots,
+    player.deck.accessories?.[0],
+    player.deck.accessories?.[1],
     player.deck.utility,
-  ].filter(Boolean);
+  ];
 
-  const gridStyle = {
-    display: 'flex',
-    flexWrap: 'wrap',
-    gap: 16,
-  };
+  const deckCount = deckSlots.filter(Boolean).length;
 
   return (
     <div style={{ padding: 16 }}>
@@ -27,11 +26,8 @@ export default function DeckBuilder({ player }) {
         <button style={{ marginBottom: 16 }}>Back to Menu</button>
       </Link>
       <h1>Deck Builder</h1>
-      <div style={gridStyle}>
-        {deck.map((card) => (
-          <Card key={card.id} card={card} />
-        ))}
-      </div>
+      <p>Equipped Cards ({deckCount})</p>
+      <DeckDisplay deck={player.deck} />
     </div>
   );
 }

--- a/game-client/src/pages/MainMenu.jsx
+++ b/game-client/src/pages/MainMenu.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import Card from '../components/Card';
+import DeckDisplay from '../components/DeckDisplay';
 
 export default function MainMenu({ player }) {
   const containerStyle = {
@@ -52,13 +52,18 @@ export default function MainMenu({ player }) {
     return <div style={containerStyle}>Loading...</div>;
   }
 
-  const deck = [
+  const deckSlots = [
     player.deck.character,
     player.deck.weapon,
-    ...Object.values(player.deck.equipment || {}),
-    ...player.deck.accessories,
+    player.deck.equipment?.body,
+    player.deck.equipment?.gloves,
+    player.deck.equipment?.boots,
+    player.deck.accessories?.[0],
+    player.deck.accessories?.[1],
     player.deck.utility,
-  ].filter(Boolean);
+  ];
+
+  const deckCount = deckSlots.filter(Boolean).length;
 
   return (
     <div style={containerStyle}>
@@ -88,12 +93,8 @@ export default function MainMenu({ player }) {
       </ul>
 
       <div style={{ marginTop: 32, textAlign: 'left' }}>
-        <h2>Deck ({deck.length})</h2>
-        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
-          {deck.map((card) => (
-            <Card key={card.id} card={card} />
-          ))}
-        </div>
+        <h2>Deck ({deckCount})</h2>
+        <DeckDisplay deck={player.deck} />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- show player deck in labelled slots on main menu
- outline deck builder page with equipped cards per slot
- add shared DeckDisplay component

## Testing
- `cd game-client && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c2ba4d13c833396ab7b96018f84a5