### PR TITLE
Add mission selection page to list missions

### DIFF
--- a/game-client/src/App.jsx
+++ b/game-client/src/App.jsx
@@ -3,6 +3,7 @@ import { Routes, Route } from 'react-router-dom';
 import MainMenu from './pages/MainMenu';
 import DeckBuilder from './pages/DeckBuilder';
 import MissionEditor from './pages/MissionEditor';
+import MissionSelection from './pages/MissionSelection';
 import examplePlayer from '../../assets/players/example_player.json';
 
 export default function App() {
@@ -13,6 +14,7 @@ export default function App() {
       <Route path="/" element={<MainMenu player={player} />} />
       <Route path="/deck" element={<DeckBuilder player={player} />} />
       <Route path="/mission-editor" element={<MissionEditor player={player} />} />
+      <Route path="/missions" element={<MissionSelection />} />
     </Routes>
   );
 }

--- a/game-client/src/pages/MainMenu.jsx
+++ b/game-client/src/pages/MainMenu.jsx
@@ -75,7 +75,9 @@ export default function MainMenu({ player }) {
       <h1>Main Menu</h1>
       <ul style={menuStyle}>
         <li>
-          <button style={buttonStyle}>Mission Selection</button>
+          <Link to="/missions">
+            <button style={buttonStyle}>Mission Selection</button>
+          </Link>
         </li>
         <li>
           <Link to="/deck">

--- a/game-client/src/pages/MissionSelection.jsx
+++ b/game-client/src/pages/MissionSelection.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+export default function MissionSelection() {
+  const modules = import.meta.glob('../../../assets/missions/*.json', { eager: true });
+  const missions = Object.values(modules).map((m) => m.default);
+
+  return (
+    <div style={{ padding: 16 }}>
+      <Link to="/">
+        <button style={{ marginBottom: 16 }}>Back to Menu</button>
+      </Link>
+      <h1>Mission Selection</h1>
+      <ul>
+        {missions.map((mission) => (
+          <li key={mission.id}>{mission.title}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/game-client/test/navigation.test.jsx
+++ b/game-client/test/navigation.test.jsx
@@ -21,6 +21,13 @@ describe('App navigation', () => {
 
     expect(await screen.findByText('Main Menu')).toBeTruthy();
 
+    fireEvent.click(screen.getByText('Mission Selection'));
+    expect(await screen.findByText('Mission Selection')).toBeTruthy();
+    expect(await screen.findByText('Whispering Corridors')).toBeTruthy();
+
+    fireEvent.click(screen.getByText('Back to Menu'));
+    expect(await screen.findByText('Main Menu')).toBeTruthy();
+
     fireEvent.click(screen.getByText('Deck Editor'));
     expect(await screen.findByText('Deck Builder')).toBeTruthy();
 


### PR DESCRIPTION
## Summary
- Add mission selection page that lists JSON missions from assets
- Wire up Main Menu "Mission Selection" button and route
- Expand navigation test coverage for new page

## Testing
- `cd game-client && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c3685ef948333bc3803ff706a9b48