### PR TITLE
Add slot types to cards and enforce deck placement

### DIFF
--- a/assets/players/example_player.json
+++ b/assets/players/example_player.json
@@ -11,6 +11,7 @@
     "character": {
       "id": "novice_warrior",
       "name": "Novice Warrior",
+      "slot": "character",
       "class": "Warrior",
       "race": "Human",
       "stats": { "str": 8, "dex": 5, "int": 3 },
@@ -20,19 +21,20 @@
     "weapon": {
       "id": "iron_sword",
       "name": "Iron Sword",
+      "slot": "weapon",
       "attack_bonus": 2,
       "skills": ["Heavy Swing"]
     },
     "equipment": {
-      "boots": { "id": "leather_boots", "name": "Leather Boots", "armor": 1 },
-      "gloves": { "id": "leather_gloves", "name": "Leather Gloves", "armor": 1 },
-      "body": { "id": "leather_armor", "name": "Leather Armor", "armor": 3 }
+      "boots": { "id": "leather_boots", "name": "Leather Boots", "slot": "boots", "armor": 1 },
+      "gloves": { "id": "leather_gloves", "name": "Leather Gloves", "slot": "gloves", "armor": 1 },
+      "body": { "id": "leather_armor", "name": "Leather Armor", "slot": "body", "armor": 3 }
     },
     "accessories": [
-      { "id": "pet_ferret", "name": "Pet Ferret", "effect": "Finds extra loot" },
-      { "id": "charm_of_luck", "name": "Charm of Luck", "effect": "+5% crit chance" }
+      { "id": "pet_ferret", "name": "Pet Ferret", "slot": "accessory", "effect": "Finds extra loot" },
+      { "id": "charm_of_luck", "name": "Charm of Luck", "slot": "accessory", "effect": "+5% crit chance" }
     ],
-    "utility": { "id": "double_jump", "name": "Double Jump", "bonus": "Access high platforms" }
+    "utility": { "id": "double_jump", "name": "Double Jump", "slot": "utility", "bonus": "Access high platforms" }
   },
   "inventory": {
     "gold": 150,
@@ -41,7 +43,9 @@
       { "id": "rope", "name": "Climbing Rope", "quantity": 1 }
     ],
     "cards": [
-      { "id": "quick_slash", "name": "Quick Slash", "type": "attack", "power": 4 }
+      { "id": "quick_slash", "name": "Quick Slash", "slot": "attack", "type": "attack", "power": 4 },
+      { "id": "steel_sword", "name": "Steel Sword", "slot": "weapon", "attack_bonus": 3, "skills": ["Piercing Strike"] },
+      { "id": "ring_of_speed", "name": "Ring of Speed", "slot": "accessory", "effect": "+2 speed" }
     ]
   }
 }

--- a/game-client/src/components/Card.jsx
+++ b/game-client/src/components/Card.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 // Basic card template that can be reused across the project
-// Accepts a `card` object and renders its name and any additional text
+// Accepts a `card` object and renders its name and data based on slot type
 export default function Card({ card }) {
   const containerStyle = {
     border: '1px solid #333',
@@ -17,11 +17,52 @@ export default function Card({ card }) {
     marginBottom: 8,
   };
 
+  function renderDetails() {
+    switch (card.slot) {
+      case 'character':
+        return (
+          <>
+            <div>Class: {card.class}</div>
+            <div>Race: {card.race}</div>
+            <div>
+              Stats: STR {card.stats?.str}, DEX {card.stats?.dex}, INT {card.stats?.int}
+            </div>
+            {card.abilities && <div>Abilities: {card.abilities.join(', ')}</div>}
+            {card.primary_attack && <div>Primary: {card.primary_attack}</div>}
+          </>
+        );
+      case 'weapon':
+        return (
+          <>
+            {card.attack_bonus !== undefined && (
+              <div>Attack Bonus: {card.attack_bonus}</div>
+            )}
+            {card.skills && <div>Skills: {card.skills.join(', ')}</div>}
+          </>
+        );
+      case 'body':
+      case 'gloves':
+      case 'boots':
+        return card.armor !== undefined ? <div>Armor: {card.armor}</div> : null;
+      case 'accessory':
+        return card.effect ? <div>{card.effect}</div> : null;
+      case 'utility':
+        return card.bonus ? <div>{card.bonus}</div> : null;
+      default:
+        return (
+          <>
+            {card.description && <div>{card.description}</div>}
+            {card.effect && <div>{card.effect}</div>}
+            {card.power !== undefined && <div>Power: {card.power}</div>}
+          </>
+        );
+    }
+  }
+
   return (
     <div style={containerStyle}>
       <div style={nameStyle}>{card.name}</div>
-      {card.description && <div>{card.description}</div>}
-      {card.effect && <div>{card.effect}</div>}
+      {renderDetails()}
     </div>
   );
 }

--- a/game-client/src/components/DeckDisplay.jsx
+++ b/game-client/src/components/DeckDisplay.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Card from './Card';
 
-export default function DeckDisplay({ deck }) {
+export default function DeckDisplay({ deck, onSlotClick }) {
   const gridStyle = {
     display: 'flex',
     flexWrap: 'wrap',
@@ -29,9 +29,12 @@ export default function DeckDisplay({ deck }) {
     background: '#f9f9f9',
   };
 
-  function renderSlot(label, card) {
+  function renderSlot(label, card, key) {
+    const handleClick = () => {
+      if (onSlotClick) onSlotClick(key);
+    };
     return (
-      <div key={label} style={slotStyle}>
+      <div key={label} style={slotStyle} onClick={handleClick}>
         <div style={labelStyle}>{label}</div>
         {card ? <Card card={card} /> : <div style={emptyStyle}>Empty</div>}
       </div>
@@ -39,15 +42,15 @@ export default function DeckDisplay({ deck }) {
   }
 
   const slots = [
-    ['Character', deck.character],
-    ['Weapon', deck.weapon],
-    ['Body', deck.equipment?.body],
-    ['Gloves', deck.equipment?.gloves],
-    ['Boots', deck.equipment?.boots],
-    ['Accessory 1', deck.accessories?.[0]],
-    ['Accessory 2', deck.accessories?.[1]],
-    ['Utility', deck.utility],
+    ['Character', deck.character, 'character'],
+    ['Weapon', deck.weapon, 'weapon'],
+    ['Body', deck.equipment?.body, 'body'],
+    ['Gloves', deck.equipment?.gloves, 'gloves'],
+    ['Boots', deck.equipment?.boots, 'boots'],
+    ['Accessory 1', deck.accessories?.[0], 'accessory1'],
+    ['Accessory 2', deck.accessories?.[1], 'accessory2'],
+    ['Utility', deck.utility, 'utility'],
   ];
 
-  return <div style={gridStyle}>{slots.map(([label, card]) => renderSlot(label, card))}</div>;
+  return <div style={gridStyle}>{slots.map(([label, card, key]) => renderSlot(label, card, key))}</div>;
 }

--- a/game-client/src/pages/DeckBuilder.jsx
+++ b/game-client/src/pages/DeckBuilder.jsx
@@ -1,24 +1,84 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import DeckDisplay from '../components/DeckDisplay';
+import Card from '../components/Card';
 
 export default function DeckBuilder({ player }) {
   if (!player) {
     return <div>Loading...</div>;
   }
 
+  const [deck, setDeck] = useState(() => JSON.parse(JSON.stringify(player.deck)));
+  const [inventory, setInventory] = useState([...player.inventory.cards]);
+  const [selected, setSelected] = useState(null);
+
   const deckSlots = [
-    player.deck.character,
-    player.deck.weapon,
-    player.deck.equipment?.body,
-    player.deck.equipment?.gloves,
-    player.deck.equipment?.boots,
-    player.deck.accessories?.[0],
-    player.deck.accessories?.[1],
-    player.deck.utility,
+    deck.character,
+    deck.weapon,
+    deck.equipment?.body,
+    deck.equipment?.gloves,
+    deck.equipment?.boots,
+    deck.accessories?.[0],
+    deck.accessories?.[1],
+    deck.utility,
   ];
 
   const deckCount = deckSlots.filter(Boolean).length;
+
+  function equipToSlot(slotKey) {
+    if (!selected) return;
+    const card = selected;
+    const allowed =
+      slotKey === 'accessory1' || slotKey === 'accessory2'
+        ? card.slot === 'accessory'
+        : card.slot === slotKey;
+    if (!allowed) {
+      alert('Card cannot be placed in this slot');
+      return;
+    }
+
+    const newDeck = { ...deck };
+    let previous = null;
+
+    switch (slotKey) {
+      case 'character':
+        previous = newDeck.character;
+        newDeck.character = card;
+        break;
+      case 'weapon':
+        previous = newDeck.weapon;
+        newDeck.weapon = card;
+        break;
+      case 'body':
+      case 'gloves':
+      case 'boots':
+        newDeck.equipment = { ...newDeck.equipment };
+        previous = newDeck.equipment[slotKey];
+        newDeck.equipment[slotKey] = card;
+        break;
+      case 'accessory1':
+      case 'accessory2':
+        newDeck.accessories = newDeck.accessories ? [...newDeck.accessories] : [];
+        const index = slotKey === 'accessory1' ? 0 : 1;
+        previous = newDeck.accessories[index];
+        newDeck.accessories[index] = card;
+        break;
+      case 'utility':
+        previous = newDeck.utility;
+        newDeck.utility = card;
+        break;
+      default:
+        break;
+    }
+
+    setDeck(newDeck);
+    setInventory((inv) => {
+      const filtered = inv.filter((c) => c.id !== card.id);
+      if (previous) filtered.push(previous);
+      return filtered;
+    });
+    setSelected(null);
+  }
 
   return (
     <div style={{ padding: 16 }}>
@@ -27,7 +87,19 @@ export default function DeckBuilder({ player }) {
       </Link>
       <h1>Deck Builder</h1>
       <p>Equipped Cards ({deckCount})</p>
-      <DeckDisplay deck={player.deck} />
+      <DeckDisplay deck={deck} onSlotClick={equipToSlot} />
+      <h2>Inventory</h2>
+      <div style={{ display: 'flex', gap: 16, flexWrap: 'wrap' }}>
+        {inventory.map((card) => (
+          <div key={card.id} style={{ textAlign: 'center' }}>
+            <Card card={card} />
+            <button onClick={() => setSelected(card)}>
+              {selected?.id === card.id ? 'Selected' : 'Select'}
+            </button>
+          </div>
+        ))}
+      </div>
+      {selected && <p>Selected card: {selected.name}</p>}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add slot metadata to all player cards and sample inventory
- render card details according to slot type and allow clicking deck slots in deck editor
- enforce slot compatibility when equipping cards and move replaced cards to inventory

## Testing
- `cd game-client && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c3e3d50588333b5723189458a8205