### PR TITLE
Document character card stats and expand example card

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,24 @@ Player decks have fixed slots to ensure consistent gameplay balance. A complete 
 - **2 Accessory cards** – such as pets, relics, charms or similar items.
 - **1 Utility card** – provides bonuses, unlocks or a multiclass option.
 
+## Character Cards
+
+Character cards define the hero leading a deck. Each stat starts at **5** and is modified by species and class choices. The available stats are:
+
+- **STR** – physical power
+- **AGI** – agility and reflexes
+- **INT** – intellect
+- **END** – endurance and toughness
+- **CHA** – charisma and social influence
+- **LCK** – luck and fortune
+- **ATK** – physical attack strength
+- **DEF** – physical defense
+- **SPATK** – special or magical attack
+- **SPDEF** – resistance to special attacks
+- **SPD** – movement speed
+
+Character cards also list abilities and the primary attack. See `assets/players/example_player.json` for a sample.
+
 ## Getting Started
 
 Each sub‑package (`game-client`) has its own `package.json`.  To install dependencies and run a development server:

--- a/assets/players/example_player.json
+++ b/assets/players/example_player.json
@@ -14,8 +14,22 @@
       "slot": "character",
       "class": "Warrior",
       "race": "Human",
-      "stats": { "str": 8, "dex": 5, "int": 3 },
-      "abilities": ["Shield Bash"],
+      "stats": {
+        "str": 8,
+        "agi": 5,
+        "int": 3,
+        "end": 6,
+        "cha": 5,
+        "lck": 5,
+        "atk": 7,
+        "def": 6,
+        "spatk": 3,
+        "spdef": 5,
+        "spd": 5
+      },
+      "abilities": [
+        "Shield Bash"
+      ],
       "primary_attack": "Slash"
     },
     "weapon": {
@@ -23,29 +37,88 @@
       "name": "Iron Sword",
       "slot": "weapon",
       "attack_bonus": 2,
-      "skills": ["Heavy Swing"]
+      "skills": [
+        "Heavy Swing"
+      ]
     },
     "equipment": {
-      "boots": { "id": "leather_boots", "name": "Leather Boots", "slot": "boots", "armor": 1 },
-      "gloves": { "id": "leather_gloves", "name": "Leather Gloves", "slot": "gloves", "armor": 1 },
-      "body": { "id": "leather_armor", "name": "Leather Armor", "slot": "body", "armor": 3 }
+      "boots": {
+        "id": "leather_boots",
+        "name": "Leather Boots",
+        "slot": "boots",
+        "armor": 1
+      },
+      "gloves": {
+        "id": "leather_gloves",
+        "name": "Leather Gloves",
+        "slot": "gloves",
+        "armor": 1
+      },
+      "body": {
+        "id": "leather_armor",
+        "name": "Leather Armor",
+        "slot": "body",
+        "armor": 3
+      }
     },
     "accessories": [
-      { "id": "pet_ferret", "name": "Pet Ferret", "slot": "accessory", "effect": "Finds extra loot" },
-      { "id": "charm_of_luck", "name": "Charm of Luck", "slot": "accessory", "effect": "+5% crit chance" }
+      {
+        "id": "pet_ferret",
+        "name": "Pet Ferret",
+        "slot": "accessory",
+        "effect": "Finds extra loot"
+      },
+      {
+        "id": "charm_of_luck",
+        "name": "Charm of Luck",
+        "slot": "accessory",
+        "effect": "+5% crit chance"
+      }
     ],
-    "utility": { "id": "double_jump", "name": "Double Jump", "slot": "utility", "bonus": "Access high platforms" }
+    "utility": {
+      "id": "double_jump",
+      "name": "Double Jump",
+      "slot": "utility",
+      "bonus": "Access high platforms"
+    }
   },
   "inventory": {
     "gold": 150,
     "items": [
-      { "id": "healing_potion", "name": "Healing Potion", "quantity": 3 },
-      { "id": "rope", "name": "Climbing Rope", "quantity": 1 }
+      {
+        "id": "healing_potion",
+        "name": "Healing Potion",
+        "quantity": 3
+      },
+      {
+        "id": "rope",
+        "name": "Climbing Rope",
+        "quantity": 1
+      }
     ],
     "cards": [
-      { "id": "quick_slash", "name": "Quick Slash", "slot": "attack", "type": "attack", "power": 4 },
-      { "id": "steel_sword", "name": "Steel Sword", "slot": "weapon", "attack_bonus": 3, "skills": ["Piercing Strike"] },
-      { "id": "ring_of_speed", "name": "Ring of Speed", "slot": "accessory", "effect": "+2 speed" }
+      {
+        "id": "quick_slash",
+        "name": "Quick Slash",
+        "slot": "attack",
+        "type": "attack",
+        "power": 4
+      },
+      {
+        "id": "steel_sword",
+        "name": "Steel Sword",
+        "slot": "weapon",
+        "attack_bonus": 3,
+        "skills": [
+          "Piercing Strike"
+        ]
+      },
+      {
+        "id": "ring_of_speed",
+        "name": "Ring of Speed",
+        "slot": "accessory",
+        "effect": "+2 speed"
+      }
     ]
   }
 }


### PR DESCRIPTION
## Summary
- expand example character stats to include STR, AGI, INT, END, CHA, LCK, ATK, DEF, SPATK, SPDEF, SPD
- document character card stats and baseline rules in README

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cdf7b56d48333a0be4ffa4273b744