### PR TITLE
Display expanded character stats

### DIFF
--- a/game-client/src/components/Card.jsx
+++ b/game-client/src/components/Card.jsx
@@ -20,13 +20,28 @@ export default function Card({ card }) {
   function renderDetails() {
     switch (card.slot) {
       case 'character':
+        const statMap = [
+          ['str', 'STR'],
+          ['agi', 'AGI'],
+          ['int', 'INT'],
+          ['end', 'END'],
+          ['cha', 'CHA'],
+          ['lck', 'LCK'],
+          ['atk', 'ATK'],
+          ['def', 'DEF'],
+          ['spatk', 'SPATK'],
+          ['spdef', 'SPDEF'],
+          ['spd', 'SPD'],
+        ];
+        const stats = statMap
+          .filter(([key]) => card.stats?.[key] !== undefined)
+          .map(([key, label]) => `${label} ${card.stats[key]}`)
+          .join(', ');
         return (
           <>
             <div>Class: {card.class}</div>
             <div>Race: {card.race}</div>
-            <div>
-              Stats: STR {card.stats?.str}, DEX {card.stats?.dex}, INT {card.stats?.int}
-            </div>
+            {stats && <div>Stats: {stats}</div>}
             {card.abilities && <div>Abilities: {card.abilities.join(', ')}</div>}
             {card.primary_attack && <div>Primary: {card.primary_attack}</div>}
           </>

--- a/game-client/test/card.test.jsx
+++ b/game-client/test/card.test.jsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import Card from '../src/components/Card.jsx';
+
+describe('Card component', () => {
+  it('renders newly added character stats', () => {
+    const card = {
+      id: 'test_char',
+      name: 'Test Character',
+      slot: 'character',
+      class: 'Warrior',
+      race: 'Human',
+      stats: {
+        str: 1,
+        agi: 2,
+        int: 3,
+        end: 4,
+        cha: 5,
+        lck: 6,
+        atk: 7,
+        def: 8,
+        spatk: 9,
+        spdef: 10,
+        spd: 11,
+      },
+    };
+
+    render(<Card card={card} />);
+    const statsElement = screen.getByText(/Stats:/);
+    const text = statsElement.textContent || '';
+    ['STR 1', 'AGI 2', 'END 4', 'SPD 11'].forEach((fragment) => {
+      expect(text.includes(fragment)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Render all new character stats (STR, AGI, INT, END, CHA, LCK, ATK, DEF, SPATK, SPDEF, SPD) on character cards
- Add unit test covering character card stats display

## Testing
- `cd game-client && npm test >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_689ce43d2f5c83339e81ad7d4a257ff6