### PR TITLE
Add mock mission player and link from mission selection

### DIFF
--- a/game-client/src/App.jsx
+++ b/game-client/src/App.jsx
@@ -4,6 +4,7 @@ import MainMenu from './pages/MainMenu';
 import DeckBuilder from './pages/DeckBuilder';
 import MissionEditor from './pages/MissionEditor';
 import MissionSelection from './pages/MissionSelection';
+import MissionPlayer from './pages/MissionPlayer';
 import examplePlayer from '../../assets/players/example_player.json';
 
 export default function App() {
@@ -15,6 +16,7 @@ export default function App() {
       <Route path="/deck" element={<DeckBuilder player={player} />} />
       <Route path="/mission-editor" element={<MissionEditor player={player} />} />
       <Route path="/missions" element={<MissionSelection />} />
+      <Route path="/missions/:missionId" element={<MissionPlayer />} />
     </Routes>
   );
 }

--- a/game-client/src/pages/MissionPlayer.jsx
+++ b/game-client/src/pages/MissionPlayer.jsx
@@ -1,0 +1,94 @@
+import React, { useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+
+// Load all mission JSON files eagerly so we can look them up by id
+const modules = import.meta.glob('../../../assets/missions/*.json', { eager: true });
+const missions = Object.values(modules).map((m) => m.default);
+
+export default function MissionPlayer() {
+  const { missionId } = useParams();
+  const mission = missions.find((m) => m.id === missionId);
+
+  const [currentRoomId, setCurrentRoomId] = useState(mission ? mission.start_room_id : null);
+  const [ended, setEnded] = useState(false);
+
+  if (!mission) {
+    return (
+      <div style={{ padding: 16 }}>
+        <Link to="/missions">
+          <button style={{ marginBottom: 16 }}>Back to Mission Selection</button>
+        </Link>
+        <p>Mission not found.</p>
+      </div>
+    );
+  }
+
+  const room = mission.rooms.find((r) => r.id === currentRoomId);
+
+  if (!room) {
+    return (
+      <div style={{ padding: 16 }}>
+        <Link to="/missions">
+          <button style={{ marginBottom: 16 }}>Back to Mission Selection</button>
+        </Link>
+        <h1>{mission.title}</h1>
+        <p>Mission complete.</p>
+      </div>
+    );
+  }
+
+  const nodes = room.auto_nodes
+    .map((id) => mission.nodes.find((n) => n.id === id))
+    .filter(Boolean);
+
+  function handleOutcome(outcome) {
+    if (outcome.move_room) {
+      setCurrentRoomId(outcome.move_room);
+    }
+    if (outcome.end_mission) {
+      setEnded(true);
+    }
+  }
+
+  function handleChoice(choice) {
+    const outcomes = choice.outcomes || choice.success_outcomes || [];
+    outcomes.forEach(handleOutcome);
+  }
+
+  function handleNodeAction(node) {
+    const outcomes = node.on_victory || [];
+    outcomes.forEach(handleOutcome);
+  }
+
+  return (
+    <div style={{ padding: 16 }}>
+      <Link to="/missions">
+        <button style={{ marginBottom: 16 }}>Back to Mission Selection</button>
+      </Link>
+      <h1>{mission.title}</h1>
+      {ended ? (
+        <p>Mission complete.</p>
+      ) : (
+        <div>
+          <h2>{room.name}</h2>
+          {nodes.map((node) => (
+            <div key={node.id} style={{ marginBottom: 16 }}>
+              <h3>{node.title}</h3>
+              <p>{node.text}</p>
+              {node.type === 'battle' ? (
+                <button onClick={() => handleNodeAction(node)}>Resolve Battle</button>
+              ) : (
+                node.choices?.map((choice, idx) => (
+                  <button key={idx} onClick={() => handleChoice(choice)} style={{ marginRight: 8 }}>
+                    {choice.label}
+                  </button>
+                ))
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/game-client/src/pages/MissionSelection.jsx
+++ b/game-client/src/pages/MissionSelection.jsx
@@ -13,7 +13,9 @@ export default function MissionSelection() {
       <h1>Mission Selection</h1>
       <ul>
         {missions.map((mission) => (
-          <li key={mission.id}>{mission.title}</li>
+          <li key={mission.id}>
+            <Link to={`/missions/${mission.id}`}>{mission.title}</Link>
+          </li>
         ))}
       </ul>
     </div>

--- a/game-client/test/navigation.test.jsx
+++ b/game-client/test/navigation.test.jsx
@@ -25,6 +25,12 @@ describe('App navigation', () => {
     expect(await screen.findByText('Mission Selection')).toBeTruthy();
     expect(await screen.findByText('Whispering Corridors')).toBeTruthy();
 
+    fireEvent.click(screen.getByText('Whispering Corridors'));
+    expect(await screen.findByText('Abandoned Palace Hall')).toBeTruthy();
+
+    fireEvent.click(screen.getByText('Back to Mission Selection'));
+    expect(await screen.findByText('Mission Selection')).toBeTruthy();
+
     fireEvent.click(screen.getByText('Back to Menu'));
     expect(await screen.findByText('Main Menu')).toBeTruthy();
 


### PR DESCRIPTION
## Summary
- add MissionPlayer page to play through mission JSONs and navigate rooms
- link mission selection entries to the new MissionPlayer and wire up route
- expand navigation tests to cover mission playback

## Testing
- `cd game-client && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ceff43a3c8333be93746af7a86a73