### PR TITLE
Add mission results screen to prevent blank post-mission view

### DIFF
--- a/assets/missions/test_mission.json
+++ b/assets/missions/test_mission.json
@@ -1,0 +1,29 @@
+{
+  "id": "test_mission",
+  "title": "Test Mission",
+  "start_room_id": "start",
+  "version": 1,
+  "rooms": [
+    {
+      "id": "start",
+      "name": "Start Room",
+      "auto_nodes": ["finish_node"],
+      "max_visible_nodes": 1
+    }
+  ],
+  "nodes": [
+    {
+      "id": "finish_node",
+      "type": "scene",
+      "room_id": "start",
+      "title": "Finish Node",
+      "text": "This mission ends immediately.",
+      "choices": [
+        {
+          "label": "Finish",
+          "outcomes": [{ "end_mission": { "success": true } }]
+        }
+      ]
+    }
+  ]
+}

--- a/game-client/src/App.jsx
+++ b/game-client/src/App.jsx
@@ -5,6 +5,7 @@ import DeckBuilder from './pages/DeckBuilder';
 import MissionEditor from './pages/MissionEditor';
 import MissionSelection from './pages/MissionSelection';
 import MissionPlayer from './pages/MissionPlayer';
+import MissionResults from './pages/MissionResults';
 import examplePlayer from '../../assets/players/example_player.json';
 
 export default function App() {
@@ -17,6 +18,7 @@ export default function App() {
       <Route path="/mission-editor" element={<MissionEditor player={player} />} />
       <Route path="/missions" element={<MissionSelection />} />
       <Route path="/missions/:missionId" element={<MissionPlayer />} />
+      <Route path="/missions/:missionId/results" element={<MissionResults />} />
     </Routes>
   );
 }

--- a/game-client/src/pages/MissionPlayer.jsx
+++ b/game-client/src/pages/MissionPlayer.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useParams, Link } from 'react-router-dom';
+import { useParams, Link, useNavigate } from 'react-router-dom';
 
 // Load all mission JSON files eagerly so we can look them up by id
 const modules = import.meta.glob('../../../assets/missions/*.json', { eager: true });
@@ -8,6 +8,7 @@ const missions = Object.values(modules).map((m) => m.default);
 export default function MissionPlayer() {
   const { missionId } = useParams();
   const mission = missions.find((m) => m.id === missionId);
+  const navigate = useNavigate();
 
   const [currentRoomId, setCurrentRoomId] = useState(mission ? mission.start_room_id : null);
   const [ended, setEnded] = useState(false);
@@ -46,6 +47,12 @@ export default function MissionPlayer() {
   useEffect(() => {
     setCurrentNodeIndex(0);
   }, [currentRoomId]);
+
+  useEffect(() => {
+    if (ended) {
+      navigate(`/missions/${missionId}/results`);
+    }
+  }, [ended, navigate, missionId]);
 
   function handleOutcome(outcome) {
     if (outcome.move_room) {

--- a/game-client/src/pages/MissionResults.jsx
+++ b/game-client/src/pages/MissionResults.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { useParams, Link } from 'react-router-dom';
+
+// Load all mission JSON files eagerly so we can look them up by id
+const modules = import.meta.glob('../../../assets/missions/*.json', { eager: true });
+const missions = Object.values(modules).map((m) => m.default);
+
+export default function MissionResults() {
+  const { missionId } = useParams();
+  const mission = missions.find((m) => m.id === missionId);
+
+  return (
+    <div style={{ padding: 16 }}>
+      <Link to="/missions">
+        <button style={{ marginBottom: 16 }}>Back to Mission Selection</button>
+      </Link>
+      <h1>{mission ? mission.title : 'Mission'}</h1>
+      <p>Mission complete.</p>
+    </div>
+  );
+}

--- a/game-client/test/navigation.test.jsx
+++ b/game-client/test/navigation.test.jsx
@@ -23,10 +23,13 @@ describe('App navigation', () => {
 
     fireEvent.click(screen.getByText('Mission Selection'));
     expect(await screen.findByText('Mission Selection')).toBeTruthy();
-    expect(await screen.findByText('Whispering Corridors')).toBeTruthy();
+    expect(await screen.findByText('Test Mission')).toBeTruthy();
 
-    fireEvent.click(screen.getByText('Whispering Corridors'));
-    expect(await screen.findByText('Abandoned Palace Hall')).toBeTruthy();
+    fireEvent.click(screen.getByText('Test Mission'));
+    expect(await screen.findByText('Start Room')).toBeTruthy();
+
+    fireEvent.click(screen.getByText('Finish'));
+    expect(await screen.findByText('Mission complete.')).toBeTruthy();
 
     fireEvent.click(screen.getByText('Back to Mission Selection'));
     expect(await screen.findByText('Mission Selection')).toBeTruthy();


### PR DESCRIPTION
## Summary
- Add dedicated mission results page shown at the end of a mission
- Route `/missions/:missionId/results` and auto-redirect on mission completion
- Add test mission and update navigation test for results flow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cf6f8482c833391cb1f8f31cc4876