### PR TITLE
Add mission results screen and mission completion test

### DIFF
--- a/game-client/src/App.jsx
+++ b/game-client/src/App.jsx
@@ -5,6 +5,7 @@ import DeckBuilder from './pages/DeckBuilder';
 import MissionEditor from './pages/MissionEditor';
 import MissionSelection from './pages/MissionSelection';
 import MissionPlayer from './pages/MissionPlayer';
+import MissionResults from './pages/MissionResults';
 import examplePlayer from '../../assets/players/example_player.json';
 
 export default function App() {
@@ -17,6 +18,7 @@ export default function App() {
       <Route path="/mission-editor" element={<MissionEditor player={player} />} />
       <Route path="/missions" element={<MissionSelection />} />
       <Route path="/missions/:missionId" element={<MissionPlayer />} />
+      <Route path="/missions/:missionId/results" element={<MissionResults />} />
     </Routes>
   );
 }

--- a/game-client/src/pages/MissionPlayer.jsx
+++ b/game-client/src/pages/MissionPlayer.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useParams, Link } from 'react-router-dom';
+import { useParams, Link, useNavigate } from 'react-router-dom';
 
 // Load all mission JSON files eagerly so we can look them up by id
 const modules = import.meta.glob('../../../assets/missions/*.json', { eager: true });
@@ -7,6 +7,7 @@ const missions = Object.values(modules).map((m) => m.default);
 
 export default function MissionPlayer() {
   const { missionId } = useParams();
+  const navigate = useNavigate();
   const mission = missions.find((m) => m.id === missionId);
 
   const [currentRoomId, setCurrentRoomId] = useState(mission ? mission.start_room_id : null);
@@ -25,27 +26,23 @@ export default function MissionPlayer() {
   }
 
   const room = mission.rooms.find((r) => r.id === currentRoomId);
-
-  if (!room) {
-    return (
-      <div style={{ padding: 16 }}>
-        <Link to="/missions">
-          <button style={{ marginBottom: 16 }}>Back to Mission Selection</button>
-        </Link>
-        <h1>{mission.title}</h1>
-        <p>Mission complete.</p>
-      </div>
-    );
-  }
-
-  const nodes = room.auto_nodes
-    .map((id) => mission.nodes.find((n) => n.id === id))
-    .filter(Boolean);
+  const nodes =
+    room?.auto_nodes.map((id) => mission.nodes.find((n) => n.id === id)).filter(Boolean) || [];
   const node = nodes[currentNodeIndex];
 
   useEffect(() => {
     setCurrentNodeIndex(0);
   }, [currentRoomId]);
+
+  useEffect(() => {
+    if (ended || !room) {
+      navigate(`/missions/${missionId}/results`);
+    }
+  }, [ended, room, navigate, missionId]);
+
+  if (ended || !room) {
+    return null;
+  }
 
   function handleOutcome(outcome) {
     if (outcome.move_room) {
@@ -94,32 +91,28 @@ export default function MissionPlayer() {
         <button style={{ marginBottom: 16 }}>Back to Mission Selection</button>
       </Link>
       <h1>{mission.title}</h1>
-      {ended ? (
-        <p>Mission complete.</p>
-      ) : (
-        <div>
-          <h2>{room.name}</h2>
-          {node && (
-            <div key={node.id} style={{ marginBottom: 16 }}>
-              <h3>{node.title}</h3>
-              <p>{node.text}</p>
-              {node.type === 'battle' ? (
-                <button onClick={() => handleNodeAction(node)}>Resolve Battle</button>
-              ) : (
-                node.choices?.map((choice, idx) => (
-                  <button
-                    key={idx}
-                    onClick={() => handleChoice(choice, node)}
-                    style={{ marginRight: 8 }}
-                  >
-                    {choice.label}
-                  </button>
-                ))
-              )}
-            </div>
-          )}
-        </div>
-      )}
+      <div>
+        <h2>{room.name}</h2>
+        {node && (
+          <div key={node.id} style={{ marginBottom: 16 }}>
+            <h3>{node.title}</h3>
+            <p>{node.text}</p>
+            {node.type === 'battle' ? (
+              <button onClick={() => handleNodeAction(node)}>Resolve Battle</button>
+            ) : (
+              node.choices?.map((choice, idx) => (
+                <button
+                  key={idx}
+                  onClick={() => handleChoice(choice, node)}
+                  style={{ marginRight: 8 }}
+                >
+                  {choice.label}
+                </button>
+              ))
+            )}
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/game-client/src/pages/MissionResults.jsx
+++ b/game-client/src/pages/MissionResults.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { useParams, Link } from 'react-router-dom';
+
+// Load all mission JSON files eagerly so we can look them up by id
+const modules = import.meta.glob('../../../assets/missions/*.json', { eager: true });
+const missions = Object.values(modules).map((m) => m.default);
+
+export default function MissionResults() {
+  const { missionId } = useParams();
+  const mission = missions.find((m) => m.id === missionId);
+
+  return (
+    <div style={{ padding: 16 }}>
+      <Link to="/missions">
+        <button style={{ marginBottom: 16 }}>Back to Mission Selection</button>
+      </Link>
+      {mission ? (
+        <>
+          <h1>Mission Results</h1>
+          <h2>{mission.title}</h2>
+          <p>Mission complete.</p>
+        </>
+      ) : (
+        <p>Mission not found.</p>
+      )}
+    </div>
+  );
+}

--- a/game-client/test/mission-results.test.jsx
+++ b/game-client/test/mission-results.test.jsx
@@ -1,0 +1,49 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import App from '../src/App.jsx';
+
+describe('Mission results', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.reject(new Error('network error'))));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('completes Whispering Corridors and shows results', async () => {
+    render(
+      <MemoryRouter initialEntries={['/missions/whispering_corridors']}>
+        <App />
+      </MemoryRouter>
+    );
+
+    // Start room
+    expect(await screen.findByText('Abandoned Palace Hall')).toBeTruthy();
+
+    // mission_intro node -> Continue
+    fireEvent.click(screen.getByText('Continue'));
+
+    // wounded_scout -> Move on
+    await screen.findByText('Wounded Scout');
+    fireEvent.click(screen.getByText('Move on'));
+
+    // collapsed_corridor -> Climb (STR check) which moves to side corridor
+    await screen.findByText('Collapsed Corridor');
+    fireEvent.click(screen.getByText('Climb (STR check)'));
+
+    // side corridor -> guards_patrol -> Resolve Battle
+    expect(await screen.findByText('Side Corridor')).toBeTruthy();
+    await screen.findByText('Palace Guards');
+    fireEvent.click(screen.getByText('Resolve Battle'));
+
+    // to_vault_antechamber -> Proceed
+    await screen.findByText('Descend the stairs');
+    fireEvent.click(screen.getByText('Proceed'));
+
+    // results screen
+    expect(await screen.findByText('Mission Results')).toBeTruthy();
+    expect(await screen.findByText('Whispering Corridors')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- navigate to a dedicated mission results page when a mission ends
- display mission title and completion message on the results screen
- test that Whispering Corridors mission reaches the results screen

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d03405b548333919c5a714b942aae