### PR TITLE
Add battle system component prototype

### DIFF
--- a/game-client/src/components/BattleSystem.jsx
+++ b/game-client/src/components/BattleSystem.jsx
@@ -1,0 +1,57 @@
+import React, { useState, useEffect } from 'react';
+
+export default function BattleSystem({
+  player = { name: 'Hero', hp: 10 },
+  enemy = { name: 'Enemy', hp: 10 },
+  onVictory,
+  onDefeat,
+}) {
+  const [playerHp, setPlayerHp] = useState(player.hp);
+  const [enemyHp, setEnemyHp] = useState(enemy.hp);
+  const [playerTurn, setPlayerTurn] = useState(true);
+
+  function attack() {
+    if (!playerTurn || playerHp <= 0 || enemyHp <= 0) return;
+    const damage = 3; // fixed for predictability
+    setEnemyHp((hp) => Math.max(0, hp - damage));
+    setPlayerTurn(false);
+  }
+
+  useEffect(() => {
+    if (!playerTurn && enemyHp > 0) {
+      const damage = 2;
+      setPlayerHp((hp) => Math.max(0, hp - damage));
+      setPlayerTurn(true);
+    }
+  }, [playerTurn, enemyHp]);
+
+  useEffect(() => {
+    if (enemyHp <= 0 && onVictory) {
+      onVictory();
+    }
+  }, [enemyHp, onVictory]);
+
+  useEffect(() => {
+    if (playerHp <= 0 && onDefeat) {
+      onDefeat();
+    }
+  }, [playerHp, onDefeat]);
+
+  return (
+    <div>
+      <div>
+        <strong>{player.name}</strong> HP: {playerHp}
+      </div>
+      <div>
+        <strong>{enemy.name}</strong> HP: {enemyHp}
+      </div>
+      {enemyHp > 0 && playerHp > 0 && (
+        <button onClick={attack} disabled={!playerTurn}>
+          Attack
+        </button>
+      )}
+      {!playerTurn && enemyHp > 0 && <p>{enemy.name} is attacking...</p>}
+    </div>
+  );
+}
+

--- a/game-client/src/pages/MissionPlayer.jsx
+++ b/game-client/src/pages/MissionPlayer.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useParams, Link } from 'react-router-dom';
+import BattleSystem from '../components/BattleSystem.jsx';
 
 // Load all mission JSON files eagerly so we can look them up by id
 const modules = import.meta.glob('../../../assets/missions/*.json', { eager: true });
@@ -104,7 +105,10 @@ export default function MissionPlayer() {
               <h3>{node.title}</h3>
               <p>{node.text}</p>
               {node.type === 'battle' ? (
-                <button onClick={() => handleNodeAction(node)}>Resolve Battle</button>
+                <BattleSystem
+                  onVictory={() => handleNodeAction(node)}
+                  onDefeat={() => setEnded(true)}
+                />
               ) : (
                 node.choices?.map((choice, idx) => (
                   <button

--- a/game-client/test/battle-system.test.jsx
+++ b/game-client/test/battle-system.test.jsx
@@ -1,0 +1,15 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import BattleSystem from '../src/components/BattleSystem.jsx';
+
+describe('BattleSystem component', () => {
+  it('triggers victory when enemy hp drops to zero', async () => {
+    const onVictory = vi.fn();
+    render(
+      <BattleSystem enemy={{ name: 'Slime', hp: 1 }} onVictory={onVictory} />
+    );
+    fireEvent.click(screen.getByText('Attack'));
+    await waitFor(() => expect(onVictory).toHaveBeenCalled());
+  });
+});
+


### PR DESCRIPTION
## Summary
- Add reusable `BattleSystem` component with simple turn-based combat mechanics
- Integrate `BattleSystem` into mission player to resolve battles
- Add basic test covering victory callback

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d03cb0b2c8333807211dcbee40878