### PR TITLE
Add turn-based battle system prototype

### DIFF
--- a/game-client/src/App.jsx
+++ b/game-client/src/App.jsx
@@ -17,7 +17,7 @@ export default function App() {
       <Route path="/deck" element={<DeckBuilder player={player} />} />
       <Route path="/mission-editor" element={<MissionEditor player={player} />} />
       <Route path="/missions" element={<MissionSelection />} />
-      <Route path="/missions/:missionId" element={<MissionPlayer />} />
+      <Route path="/missions/:missionId" element={<MissionPlayer player={player} />} />
       <Route path="/missions/:missionId/results" element={<MissionResults />} />
     </Routes>
   );

--- a/game-client/src/components/BattleSystem.jsx
+++ b/game-client/src/components/BattleSystem.jsx
@@ -1,0 +1,70 @@
+import React, { useState } from 'react';
+
+/**
+ * Simple turn-based battle prototype.
+ * Uses the player's deck to determine stats and available actions.
+ */
+export default function BattleSystem({ deck, onVictory, onDefeat }) {
+  const maxPlayerHp = deck?.character?.stats?.end ? deck.character.stats.end * 2 : 20;
+  const attackPower = (deck?.character?.stats?.atk || 0) + (deck?.weapon?.attack_bonus || 0);
+  const actions = [
+    deck?.character?.primary_attack,
+    ...(deck?.character?.abilities || []),
+    ...(deck?.weapon?.skills || []),
+  ].filter(Boolean);
+
+  const [playerHp, setPlayerHp] = useState(maxPlayerHp);
+  const [enemyHp, setEnemyHp] = useState(20);
+  const [log, setLog] = useState([]);
+
+  function addLog(msg) {
+    setLog((prev) => [...prev, msg]);
+  }
+
+  function handleAction(label) {
+    // Player attacks
+    const newEnemyHp = enemyHp - attackPower;
+    addLog(`You use ${label} for ${attackPower} damage.`);
+    if (newEnemyHp <= 0) {
+      setEnemyHp(0);
+      addLog('Enemy defeated!');
+      onVictory && onVictory();
+      return;
+    }
+    setEnemyHp(newEnemyHp);
+
+    // Enemy counterattacks
+    const enemyDamage = 5;
+    const newPlayerHp = playerHp - enemyDamage;
+    addLog(`Enemy strikes back for ${enemyDamage} damage.`);
+    if (newPlayerHp <= 0) {
+      setPlayerHp(0);
+      addLog('You were defeated...');
+      onDefeat && onDefeat();
+      return;
+    }
+    setPlayerHp(newPlayerHp);
+  }
+
+  return (
+    <div>
+      <p>Player HP: {playerHp}</p>
+      <p>Enemy HP: {enemyHp}</p>
+      {playerHp > 0 && enemyHp > 0 && (
+        <div style={{ marginBottom: 8 }}>
+          {actions.map((action) => (
+            <button key={action} onClick={() => handleAction(action)} style={{ marginRight: 8 }}>
+              {action}
+            </button>
+          ))}
+        </div>
+      )}
+      <div style={{ minHeight: 60 }}>
+        {log.map((entry, idx) => (
+          <div key={idx}>{entry}</div>
+        ))}
+      </div>
+    </div>
+  );
+}
+

--- a/game-client/src/pages/MissionPlayer.jsx
+++ b/game-client/src/pages/MissionPlayer.jsx
@@ -1,11 +1,12 @@
 import React, { useState, useEffect } from 'react';
 import { useParams, Link, useNavigate } from 'react-router-dom';
+import BattleSystem from '../components/BattleSystem.jsx';
 
 // Load all mission JSON files eagerly so we can look them up by id
 const modules = import.meta.glob('../../../assets/missions/*.json', { eager: true });
 const missions = Object.values(modules).map((m) => m.default);
 
-export default function MissionPlayer() {
+export default function MissionPlayer({ player }) {
   const { missionId } = useParams();
   const navigate = useNavigate();
   const mission = missions.find((m) => m.id === missionId);
@@ -71,8 +72,8 @@ export default function MissionPlayer() {
     }
   }
 
-  function handleNodeAction(node) {
-    const outcomes = node.on_victory || [];
+  function handleBattleOutcome(victory, node) {
+    const outcomes = victory ? node.on_victory || [] : node.on_defeat || [];
     let moved = false;
     let finished = false;
     outcomes.forEach((o) => {
@@ -98,7 +99,11 @@ export default function MissionPlayer() {
             <h3>{node.title}</h3>
             <p>{node.text}</p>
             {node.type === 'battle' ? (
-              <button onClick={() => handleNodeAction(node)}>Resolve Battle</button>
+              <BattleSystem
+                deck={player.deck}
+                onVictory={() => handleBattleOutcome(true, node)}
+                onDefeat={() => handleBattleOutcome(false, node)}
+              />
             ) : (
               node.choices?.map((choice, idx) => (
                 <button

--- a/game-client/test/mission-results.test.jsx
+++ b/game-client/test/mission-results.test.jsx
@@ -33,10 +33,12 @@ describe('Mission results', () => {
     await screen.findByText('Collapsed Corridor');
     fireEvent.click(screen.getByText('Climb (STR check)'));
 
-    // side corridor -> guards_patrol -> Resolve Battle
+    // side corridor -> guards_patrol -> battle
     expect(await screen.findByText('Side Corridor')).toBeTruthy();
     await screen.findByText('Palace Guards');
-    fireEvent.click(screen.getByText('Resolve Battle'));
+    for (let i = 0; i < 3; i++) {
+      fireEvent.click(await screen.findByText('Slash'));
+    }
 
     // to_vault_antechamber -> Proceed
     await screen.findByText('Descend the stairs');


### PR DESCRIPTION
## Summary
- add basic BattleSystem component that derives player stats and actions from deck
- integrate battle component into MissionPlayer and pass player deck through App
- update mission results test to simulate battle

## Testing
- `cd game-client && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d07b0b62c8333ada0f6bb79cd4b72