### PR TITLE
Enable deck saving and adjust Quick Slash to utility slot

### DIFF
--- a/assets/players/example_player.json
+++ b/assets/players/example_player.json
@@ -100,9 +100,9 @@
       {
         "id": "quick_slash",
         "name": "Quick Slash",
-        "slot": "attack",
-        "type": "attack",
-        "power": 4
+        "slot": "utility",
+        "type": "utility",
+        "bonus": "React swiftly to gain an extra edge"
       },
       {
         "id": "steel_sword",

--- a/game-client/src/App.jsx
+++ b/game-client/src/App.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Routes, Route } from 'react-router-dom';
 import MainMenu from './pages/MainMenu';
 import DeckBuilder from './pages/DeckBuilder';
@@ -9,12 +9,27 @@ import MissionResults from './pages/MissionResults';
 import examplePlayer from '../../assets/players/example_player.json';
 
 export default function App() {
-  const player = examplePlayer;
+  const [player, setPlayer] = useState(() => {
+    try {
+      const saved = localStorage.getItem('player');
+      return saved ? JSON.parse(saved) : examplePlayer;
+    } catch {
+      return examplePlayer;
+    }
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem('player', JSON.stringify(player));
+    } catch {
+      // ignore write errors
+    }
+  }, [player]);
 
   return (
     <Routes>
       <Route path="/" element={<MainMenu player={player} />} />
-      <Route path="/deck" element={<DeckBuilder player={player} />} />
+      <Route path="/deck" element={<DeckBuilder player={player} setPlayer={setPlayer} />} />
       <Route path="/mission-editor" element={<MissionEditor player={player} />} />
       <Route path="/missions" element={<MissionSelection />} />
       <Route path="/missions/:missionId" element={<MissionPlayer player={player} />} />

--- a/game-client/src/pages/DeckBuilder.jsx
+++ b/game-client/src/pages/DeckBuilder.jsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import DeckDisplay from '../components/DeckDisplay';
 import Card from '../components/Card';
 
-export default function DeckBuilder({ player }) {
+export default function DeckBuilder({ player, setPlayer }) {
   if (!player) {
     return <div>Loading...</div>;
   }
@@ -80,11 +80,23 @@ export default function DeckBuilder({ player }) {
     setSelected(null);
   }
 
+  function saveDeck() {
+    if (!setPlayer) return;
+    setPlayer((p) => ({
+      ...p,
+      deck,
+      inventory: { ...p.inventory, cards: inventory },
+    }));
+  }
+
   return (
     <div style={{ padding: 16 }}>
-      <Link to="/">
-        <button style={{ marginBottom: 16 }}>Back to Menu</button>
-      </Link>
+      <div style={{ marginBottom: 16, display: 'flex', gap: 8 }}>
+        <Link to="/">
+          <button>Back to Menu</button>
+        </Link>
+        <button onClick={saveDeck}>Save Deck</button>
+      </div>
       <h1>Deck Builder</h1>
       <p>Equipped Cards ({deckCount})</p>
       <DeckDisplay deck={deck} onSlotClick={equipToSlot} />


### PR DESCRIPTION
## Summary
- Make Quick Slash card a utility card so it fits the utility slot
- Persist deck and inventory changes with a Save Deck button in DeckBuilder
- Store player state in localStorage via App to keep edits

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d0a579de48333ac920b5fc59e2574