### PR TITLE
Improve mission layout spacing and typewriter

### DIFF
--- a/game-client/src/components/TypewriterText.jsx
+++ b/game-client/src/components/TypewriterText.jsx
@@ -8,7 +8,8 @@ export default function TypewriterText({ text, speed = 30 }) {
     if (!text) return;
     let i = 0;
     const interval = setInterval(() => {
-      setDisplayed((prev) => prev + text[i]);
+      const char = text.charAt(i);
+      setDisplayed((prev) => prev + char);
       i += 1;
       if (i >= text.length) {
         clearInterval(interval);

--- a/game-client/src/pages/MissionPlayer.jsx
+++ b/game-client/src/pages/MissionPlayer.jsx
@@ -88,23 +88,30 @@ export default function MissionPlayer({ player }) {
   }
 
   return (
-    <div style={{ padding: 16 }}>
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        minHeight: '100vh',
+        padding: 16,
+      }}
+    >
       <Link to="/missions">
-        <button style={{ marginBottom: 16 }}>Back to Mission Selection</button>
+        <button style={{ marginBottom: 32 }}>Back to Mission Selection</button>
       </Link>
-      <h1 style={{ marginBottom: 8 }}>Mission Name</h1>
-      <p style={{ marginBottom: 24 }}>{mission.title}</p>
-      <h2 style={{ marginBottom: 8 }}>Room Name</h2>
-      <p style={{ marginBottom: 24 }}>{room.name}</p>
+      <h1 style={{ marginBottom: 16 }}>Mission Name</h1>
+      <p style={{ marginBottom: 32 }}>{mission.title}</p>
+      <h2 style={{ marginBottom: 16 }}>Room Name</h2>
+      <p style={{ marginBottom: 32 }}>{room.name}</p>
       {node && (
-        <div key={node.id} style={{ marginBottom: 24 }}>
-          <h3 style={{ marginBottom: 8 }}>Event Title</h3>
-          <p style={{ marginBottom: 16 }}>{node.title}</p>
-          <h3 style={{ marginBottom: 8 }}>Event Description</h3>
-          <p style={{ marginBottom: 16 }}>
+        <div key={node.id} style={{ marginTop: 'auto' }}>
+          <h3 style={{ marginBottom: 16 }}>Event Title</h3>
+          <p style={{ marginBottom: 24 }}>{node.title}</p>
+          <h3 style={{ marginBottom: 16 }}>Event Description</h3>
+          <p style={{ marginBottom: 24 }}>
             <TypewriterText text={node.text} />
           </p>
-          <h3 style={{ marginBottom: 8 }}>Options</h3>
+          <h3 style={{ marginBottom: 16 }}>Options</h3>
           {node.type === 'battle' ? (
             <BattleSystem
               deck={player.deck}


### PR DESCRIPTION
## Summary
- Push mission events to bottom of layout with flexbox and add larger spacing for mission details
- Fix typewriter skipping second character by capturing current character before advancing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d136e91648333bb389c03063adbed