### PR TITLE
Document room data in mission editor

### DIFF
--- a/docs/mission_editor_node_graph.md
+++ b/docs/mission_editor_node_graph.md
@@ -10,3 +10,31 @@ The mission editor represents stories as a graph of rooms and nodes. When starti
 3. **Connect the intro node** to other nodes as desired, but ensure that every path ultimately leads to an **end mission node**.
 
 Following this pattern guarantees a valid starting point while leaving flexibility for multiple start points and branching paths as the mission evolves.
+
+## Room Data
+
+Each room acts as a container for nodes and defines how players transition to other locations. The mission editor stores room information using the following fields:
+
+| Field        | Type   | Description                                                                  |
+|------------- |--------|------------------------------------------------------------------------------|
+| `id`         | string | Unique room identifier used by nodes and exits                              |
+| `name`       | string | Display name shown in the editor                                            |
+| `art`        | string | Optional path to background art                                             |
+| `music`      | string | Optional background music track                                             |
+| `exits`      | array  | List of exits; each has a `to` room id and `label` for the connection       |
+| `auto_nodes` | array  | IDs of nodes that are automatically revealed when the room is entered       |
+
+Example room JSON:
+
+```json
+{
+  "id": "start",
+  "name": "Entryway",
+  "art": "img/entry.png",
+  "music": "bgm/intro.mp3",
+  "exits": [
+    { "to": "hall", "label": "Hallway" }
+  ],
+  "auto_nodes": ["intro_node"]
+}
+```


### PR DESCRIPTION
## Summary
- describe the fields used to define a room in the mission editor
- include example JSON snippet showing room structure

## Testing
- `cd game-client && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d1f4f3c1883338e07dc06a048c191