### PR TITLE
Add mission editor graph and menu link

### DIFF
--- a/game-client/package.json
+++ b/game-client/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.30.1"
+    "react-router-dom": "^6.30.1",
+    "reactflow": "^11.11.4"
   },
   "devDependencies": {
     "@testing-library/react": "^14.2.1",

--- a/game-client/package.json
+++ b/game-client/package.json
@@ -9,6 +9,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@reactflow/node-resizer": "^2.2.14",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.30.1",

--- a/game-client/src/components/MissionGraph.jsx
+++ b/game-client/src/components/MissionGraph.jsx
@@ -47,7 +47,13 @@ export default function MissionGraph({
         id,
         type,
         position,
-        data: { label: 'Room' },
+        data: {
+          name: 'Room',
+          art: '',
+          music: '',
+          exits: [],
+          auto_nodes: [],
+        },
         style: { width: 200, height: 150 },
       };
       setNodes((nds) => nds.concat(newNode));

--- a/game-client/src/components/MissionGraph.jsx
+++ b/game-client/src/components/MissionGraph.jsx
@@ -1,45 +1,70 @@
-import React, { useCallback } from 'react';
-import ReactFlow, {
-  Background,
-  Controls,
-  addEdge,
-  useNodesState,
-  useEdgesState,
-} from 'reactflow';
+import React, { useCallback, useRef } from 'react';
+import ReactFlow, { Background, Controls } from 'reactflow';
 import 'reactflow/dist/style.css';
 
-const initialNodes = [
-  {
-    id: 'room-1',
-    type: 'input',
-    position: { x: 250, y: 0 },
-    data: { label: 'Start Room' },
-  },
-];
-
-const initialEdges = [];
-
-export default function MissionGraph() {
-  if (typeof window === 'undefined' || typeof window.ResizeObserver === 'undefined') {
+export default function MissionGraph({
+  nodes,
+  edges,
+  setNodes,
+  onNodesChange,
+  onEdgesChange,
+  onConnect,
+  onNodeSelect,
+}) {
+  if (
+    typeof window === 'undefined' ||
+    typeof window.ResizeObserver === 'undefined'
+  ) {
     // Avoid rendering React Flow during server-side rendering or tests
     return <div style={{ width: '100%', height: 600, background: '#f0f0f0' }} />;
   }
-  const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
-  const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
 
-  const onConnect = useCallback(
-    (connection) => setEdges((eds) => addEdge(connection, eds)),
-    [setEdges]
+  const reactFlowWrapper = useRef(null);
+  const reactFlowInstance = useRef(null);
+
+  const onDragOver = useCallback((event) => {
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'move';
+  }, []);
+
+  const onDrop = useCallback(
+    (event) => {
+      event.preventDefault();
+      const type = event.dataTransfer.getData('application/reactflow');
+      if (!type) return;
+
+      const reactFlowBounds = reactFlowWrapper.current.getBoundingClientRect();
+      const position = reactFlowInstance.current.project({
+        x: event.clientX - reactFlowBounds.left,
+        y: event.clientY - reactFlowBounds.top,
+      });
+
+      const id = `${type}-${nodes.length + 1}`;
+      const newNode = {
+        id,
+        type: 'default',
+        position,
+        data: { label: 'Room' },
+      };
+      setNodes((nds) => nds.concat(newNode));
+    },
+    [nodes, setNodes]
   );
 
   return (
-    <div style={{ width: '100%', height: 600 }}>
+    <div style={{ flex: 1 }} ref={reactFlowWrapper}>
       <ReactFlow
         nodes={nodes}
         edges={edges}
         onNodesChange={onNodesChange}
         onEdgesChange={onEdgesChange}
         onConnect={onConnect}
+        onDrop={onDrop}
+        onDragOver={onDragOver}
+        onSelectionChange={({ nodes: selected }) =>
+          onNodeSelect(selected[0] || null)
+        }
+        onInit={(instance) => (reactFlowInstance.current = instance)}
         fitView
       >
         <Controls />

--- a/game-client/src/components/MissionGraph.jsx
+++ b/game-client/src/components/MissionGraph.jsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useRef } from 'react';
 import ReactFlow, { Background, Controls } from 'reactflow';
 import 'reactflow/dist/style.css';
+import RoomNode from './RoomNode';
 
 export default function MissionGraph({
   nodes,
@@ -22,6 +23,8 @@ export default function MissionGraph({
   const reactFlowWrapper = useRef(null);
   const reactFlowInstance = useRef(null);
 
+  const nodeTypes = { room: RoomNode };
+
   const onDragOver = useCallback((event) => {
     event.preventDefault();
     event.dataTransfer.dropEffect = 'move';
@@ -42,9 +45,10 @@ export default function MissionGraph({
       const id = `${type}-${nodes.length + 1}`;
       const newNode = {
         id,
-        type: 'default',
+        type,
         position,
         data: { label: 'Room' },
+        style: { width: 200, height: 150 },
       };
       setNodes((nds) => nds.concat(newNode));
     },
@@ -56,6 +60,7 @@ export default function MissionGraph({
       <ReactFlow
         nodes={nodes}
         edges={edges}
+        nodeTypes={nodeTypes}
         onNodesChange={onNodesChange}
         onEdgesChange={onEdgesChange}
         onConnect={onConnect}

--- a/game-client/src/components/MissionGraph.jsx
+++ b/game-client/src/components/MissionGraph.jsx
@@ -1,0 +1,50 @@
+import React, { useCallback } from 'react';
+import ReactFlow, {
+  Background,
+  Controls,
+  addEdge,
+  useNodesState,
+  useEdgesState,
+} from 'reactflow';
+import 'reactflow/dist/style.css';
+
+const initialNodes = [
+  {
+    id: 'room-1',
+    type: 'input',
+    position: { x: 250, y: 0 },
+    data: { label: 'Start Room' },
+  },
+];
+
+const initialEdges = [];
+
+export default function MissionGraph() {
+  if (typeof window === 'undefined' || typeof window.ResizeObserver === 'undefined') {
+    // Avoid rendering React Flow during server-side rendering or tests
+    return <div style={{ width: '100%', height: 600, background: '#f0f0f0' }} />;
+  }
+  const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
+  const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
+
+  const onConnect = useCallback(
+    (connection) => setEdges((eds) => addEdge(connection, eds)),
+    [setEdges]
+  );
+
+  return (
+    <div style={{ width: '100%', height: 600 }}>
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
+        onConnect={onConnect}
+        fitView
+      >
+        <Controls />
+        <Background gap={16} />
+      </ReactFlow>
+    </div>
+  );
+}

--- a/game-client/src/components/NodeInspector.jsx
+++ b/game-client/src/components/NodeInspector.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+export default function NodeInspector({ selectedNode, onChange }) {
+  if (!selectedNode) {
+    return (
+      <aside style={{ padding: 8, borderLeft: '1px solid #ccc', width: 200 }}>
+        <h3 style={{ marginTop: 0 }}>Inspector</h3>
+        <div>No node selected</div>
+      </aside>
+    );
+  }
+
+  const { id, data } = selectedNode;
+
+  const handleLabelChange = (e) => {
+    onChange({ ...selectedNode, data: { ...data, label: e.target.value } });
+  };
+
+  return (
+    <aside style={{ padding: 8, borderLeft: '1px solid #ccc', width: 200 }}>
+      <h3 style={{ marginTop: 0 }}>Inspector</h3>
+      <div style={{ marginBottom: 8 }}>ID: {id}</div>
+      <label>
+        Label:
+        <input
+          type="text"
+          value={data.label || ''}
+          onChange={handleLabelChange}
+          style={{ width: '100%' }}
+        />
+      </label>
+    </aside>
+  );
+}

--- a/game-client/src/components/NodeInspector.jsx
+++ b/game-client/src/components/NodeInspector.jsx
@@ -12,8 +12,26 @@ export default function NodeInspector({ selectedNode, onChange }) {
 
   const { id, data } = selectedNode;
 
-  const handleNameChange = (e) => {
-    onChange({ ...selectedNode, data: { ...data, label: e.target.value } });
+  const handleFieldChange = (field, value) => {
+    onChange({ ...selectedNode, data: { ...data, [field]: value } });
+  };
+
+  const handleAutoNodesChange = (e) => {
+    const parts = e.target.value
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+    handleFieldChange('auto_nodes', parts);
+  };
+
+  const handleExitsChange = (e) => {
+    let exits = data.exits || [];
+    try {
+      exits = JSON.parse(e.target.value);
+    } catch {
+      // ignore parse errors and keep previous value
+    }
+    handleFieldChange('exits', exits);
   };
 
   return (
@@ -24,9 +42,44 @@ export default function NodeInspector({ selectedNode, onChange }) {
         Name:
         <input
           type="text"
-          value={data.label || ''}
-          onChange={handleNameChange}
+          value={data.name || ''}
+          onChange={(e) => handleFieldChange('name', e.target.value)}
           style={{ width: '100%' }}
+        />
+      </label>
+      <label>
+        Art:
+        <input
+          type="text"
+          value={data.art || ''}
+          onChange={(e) => handleFieldChange('art', e.target.value)}
+          style={{ width: '100%' }}
+        />
+      </label>
+      <label>
+        Music:
+        <input
+          type="text"
+          value={data.music || ''}
+          onChange={(e) => handleFieldChange('music', e.target.value)}
+          style={{ width: '100%' }}
+        />
+      </label>
+      <label>
+        Auto Nodes (comma separated):
+        <input
+          type="text"
+          value={(data.auto_nodes || []).join(',')}
+          onChange={handleAutoNodesChange}
+          style={{ width: '100%' }}
+        />
+      </label>
+      <label>
+        Exits (JSON):
+        <textarea
+          value={JSON.stringify(data.exits || [])}
+          onChange={handleExitsChange}
+          style={{ width: '100%', height: 80 }}
         />
       </label>
     </aside>

--- a/game-client/src/components/NodeInspector.jsx
+++ b/game-client/src/components/NodeInspector.jsx
@@ -12,7 +12,7 @@ export default function NodeInspector({ selectedNode, onChange }) {
 
   const { id, data } = selectedNode;
 
-  const handleLabelChange = (e) => {
+  const handleNameChange = (e) => {
     onChange({ ...selectedNode, data: { ...data, label: e.target.value } });
   };
 
@@ -21,11 +21,11 @@ export default function NodeInspector({ selectedNode, onChange }) {
       <h3 style={{ marginTop: 0 }}>Inspector</h3>
       <div style={{ marginBottom: 8 }}>ID: {id}</div>
       <label>
-        Label:
+        Name:
         <input
           type="text"
           value={data.label || ''}
-          onChange={handleLabelChange}
+          onChange={handleNameChange}
           style={{ width: '100%' }}
         />
       </label>

--- a/game-client/src/components/NodeLibrary.jsx
+++ b/game-client/src/components/NodeLibrary.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+export default function NodeLibrary() {
+  const onDragStart = (event, nodeType) => {
+    event.dataTransfer.setData('application/reactflow', nodeType);
+    event.dataTransfer.effectAllowed = 'move';
+  };
+
+  return (
+    <aside style={{ padding: 8, borderRight: '1px solid #ccc', width: 150 }}>
+      <h3 style={{ marginTop: 0 }}>Nodes</h3>
+      <div
+        style={{ padding: 8, border: '1px solid #999', borderRadius: 4, cursor: 'grab' }}
+        onDragStart={(event) => onDragStart(event, 'room')}
+        draggable
+      >
+        Room Node
+      </div>
+    </aside>
+  );
+}

--- a/game-client/src/components/RoomNode.jsx
+++ b/game-client/src/components/RoomNode.jsx
@@ -27,7 +27,7 @@ export default function RoomNode({ data, selected }) {
           fontWeight: 'bold',
         }}
       >
-        {data.label || 'Room'}
+        {data.name || 'Room'}
       </div>
       <div style={{ flex: 1 }} />
     </div>

--- a/game-client/src/components/RoomNode.jsx
+++ b/game-client/src/components/RoomNode.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { NodeResizer } from '@reactflow/node-resizer';
+import '@reactflow/node-resizer/dist/style.css';
+
+export default function RoomNode({ data, selected }) {
+  return (
+    <div
+      style={{
+        background: 'rgba(255, 255, 255, 0.9)',
+        border: '1px solid #888',
+        borderRadius: 4,
+        width: '100%',
+        height: '100%',
+        position: 'relative',
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
+      <NodeResizer minWidth={150} minHeight={100} isVisible={selected} />
+      <div
+        style={{
+          background: '#333',
+          color: '#fff',
+          padding: '4px 8px',
+          borderTopLeftRadius: 4,
+          borderTopRightRadius: 4,
+          fontWeight: 'bold',
+        }}
+      >
+        {data.label || 'Room'}
+      </div>
+      <div style={{ flex: 1 }} />
+    </div>
+  );
+}

--- a/game-client/src/pages/MainMenu.jsx
+++ b/game-client/src/pages/MainMenu.jsx
@@ -89,7 +89,9 @@ export default function MainMenu({ player }) {
         </li>
         <li>
           <Link to="/mission-editor">
-            <button style={buttonStyle}>Mission Editor</button>
+            <button style={buttonStyle} aria-label="Open Mission Editor">
+              Mission Editor
+            </button>
           </Link>
         </li>
       </ul>

--- a/game-client/src/pages/MissionEditor.jsx
+++ b/game-client/src/pages/MissionEditor.jsx
@@ -1,15 +1,47 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import { Link } from 'react-router-dom';
 import MissionGraph from '../components/MissionGraph';
+import NodeLibrary from '../components/NodeLibrary';
+import NodeInspector from '../components/NodeInspector';
+import { addEdge, useEdgesState, useNodesState } from 'reactflow';
 
 export default function MissionEditor() {
+  const [nodes, setNodes, onNodesChange] = useNodesState([]);
+  const [edges, setEdges, onEdgesChange] = useEdgesState([]);
+  const [selectedNode, setSelectedNode] = useState(null);
+
+  const onConnect = useCallback(
+    (connection) => setEdges((eds) => addEdge(connection, eds)),
+    [setEdges]
+  );
+
+  const handleNodeUpdate = useCallback(
+    (updatedNode) => {
+      setNodes((nds) => nds.map((n) => (n.id === updatedNode.id ? updatedNode : n)));
+      setSelectedNode(updatedNode);
+    },
+    [setNodes]
+  );
+
   return (
     <div style={{ padding: 16 }}>
       <Link to="/">
         <button style={{ marginBottom: 16 }}>Back to Menu</button>
       </Link>
       <h1>Mission Editor</h1>
-      <MissionGraph />
+      <div style={{ display: 'flex', height: 600 }}>
+        <NodeLibrary />
+        <MissionGraph
+          nodes={nodes}
+          edges={edges}
+          setNodes={setNodes}
+          onNodesChange={onNodesChange}
+          onEdgesChange={onEdgesChange}
+          onConnect={onConnect}
+          onNodeSelect={setSelectedNode}
+        />
+        <NodeInspector selectedNode={selectedNode} onChange={handleNodeUpdate} />
+      </div>
       <p style={{ marginTop: 16 }}>Mission editor content coming soon.</p>
     </div>
   );

--- a/game-client/src/pages/MissionEditor.jsx
+++ b/game-client/src/pages/MissionEditor.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import MissionGraph from '../components/MissionGraph';
 
 export default function MissionEditor() {
   return (
@@ -8,7 +9,8 @@ export default function MissionEditor() {
         <button style={{ marginBottom: 16 }}>Back to Menu</button>
       </Link>
       <h1>Mission Editor</h1>
-      <p>Mission editor content coming soon.</p>
+      <MissionGraph />
+      <p style={{ marginTop: 16 }}>Mission editor content coming soon.</p>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add React Flow dependency and MissionGraph component
- embed basic mission graph in MissionEditor page
- expose mission editor via main menu navigation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d2d4f81a883338c7b9766c194d332