### PR TITLE
Show mission fields when no node selected

### DIFF
--- a/game-client/src/components/NodeInspector.jsx
+++ b/game-client/src/components/NodeInspector.jsx
@@ -1,11 +1,46 @@
 import React from 'react';
 
-export default function NodeInspector({ selectedNode, onChange }) {
+export default function NodeInspector({
+  selectedNode,
+  onChange,
+  mission,
+  onMissionChange,
+}) {
   if (!selectedNode) {
+    const handleMissionFieldChange = (field, value) => {
+      onMissionChange({ ...mission, [field]: value });
+    };
+
     return (
       <aside style={{ padding: 8, borderLeft: '1px solid #ccc', width: 200 }}>
-        <h3 style={{ marginTop: 0 }}>Inspector</h3>
-        <div>No node selected</div>
+        <h3 style={{ marginTop: 0 }}>Mission</h3>
+        <label>
+          Start Room ID:
+          <input
+            type="text"
+            value={mission.start_room_id || ''}
+            onChange={(e) =>
+              handleMissionFieldChange('start_room_id', e.target.value)
+            }
+            style={{ width: '100%' }}
+          />
+        </label>
+        <label>
+          Rooms:
+          <textarea
+            value={JSON.stringify(mission.rooms || [], null, 2)}
+            readOnly
+            style={{ width: '100%', height: 80 }}
+          />
+        </label>
+        <label>
+          Nodes:
+          <textarea
+            value={JSON.stringify(mission.nodes || [], null, 2)}
+            readOnly
+            style={{ width: '100%', height: 80 }}
+          />
+        </label>
       </aside>
     );
   }

--- a/game-client/src/pages/MissionEditor.jsx
+++ b/game-client/src/pages/MissionEditor.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import MissionGraph from '../components/MissionGraph';
 import NodeLibrary from '../components/NodeLibrary';
@@ -9,6 +9,21 @@ export default function MissionEditor() {
   const [nodes, setNodes, onNodesChange] = useNodesState([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState([]);
   const [selectedNodeId, setSelectedNodeId] = useState(null);
+  const [startRoomId, setStartRoomId] = useState('');
+
+  const mission = useMemo(
+    () => ({
+      start_room_id: startRoomId,
+      rooms: nodes.map(({ id, data }) => ({ id, ...data })),
+      nodes: nodes.map(({ id, data }) => ({ id, ...data })),
+    }),
+    [startRoomId, nodes]
+  );
+
+  const handleMissionChange = useCallback(
+    (updatedMission) => setStartRoomId(updatedMission.start_room_id || ''),
+    []
+  );
 
   const onConnect = useCallback(
     (connection) => setEdges((eds) => addEdge(connection, eds)),
@@ -42,7 +57,12 @@ export default function MissionEditor() {
           onConnect={onConnect}
           onNodeSelect={(node) => setSelectedNodeId(node ? node.id : null)}
         />
-        <NodeInspector selectedNode={selectedNode} onChange={handleNodeUpdate} />
+        <NodeInspector
+          selectedNode={selectedNode}
+          onChange={handleNodeUpdate}
+          mission={mission}
+          onMissionChange={handleMissionChange}
+        />
       </div>
       <p style={{ marginTop: 16 }}>Mission editor content coming soon.</p>
     </div>


### PR DESCRIPTION
## Summary
- display mission-level settings when no node is selected in mission editor
- track start room and auto-populate rooms and nodes lists from graph

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d3c13ca088333864f88b850e2d1c3