### PR TITLE
Add mission intro choice editing

### DIFF
--- a/game-client/src/components/MissionGraph.jsx
+++ b/game-client/src/components/MissionGraph.jsx
@@ -74,7 +74,7 @@ export default function MissionGraph({
             exits: [],
             auto_nodes: [],
           },
-          style: { width: 200, height: 150, zIndex: 0 },
+          style: { width: 200, height: 150, zIndex: -1 },
         };
         setNodes((nds) => nds.concat(newNode));
         onLibraryDragEnd?.();

--- a/game-client/src/components/MissionGraph.jsx
+++ b/game-client/src/components/MissionGraph.jsx
@@ -3,6 +3,7 @@ import ReactFlow, { Background, Controls } from 'reactflow';
 import 'reactflow/dist/style.css';
 import RoomNode from './RoomNode';
 import MissionIntroNode from './MissionIntroNode';
+import NpcNode from './NpcNode';
 import './MissionGraph.css';
 
 export default function MissionGraph({
@@ -27,7 +28,7 @@ export default function MissionGraph({
   const reactFlowWrapper = useRef(null);
   const reactFlowInstance = useRef(null);
 
-  const nodeTypes = { room: RoomNode, mission_intro: MissionIntroNode };
+  const nodeTypes = { room: RoomNode, mission_intro: MissionIntroNode, npc: NpcNode };
 
   const findRoomAtPosition = (position, graphNodes) =>
     graphNodes.find((n) => {
@@ -80,7 +81,7 @@ export default function MissionGraph({
         return;
       }
 
-      if (type === 'mission_intro') {
+      if (type === 'mission_intro' || type === 'npc') {
         const graphNodes = reactFlowInstance.current.getNodes();
         const parent = findRoomAtPosition(position, graphNodes);
 
@@ -93,12 +94,19 @@ export default function MissionGraph({
                 y: position.y - parent.position.y,
               }
             : position,
-          data: {
-            title: '',
-            text: '',
-            room_id: parent ? parent.id : '',
-            choices: [],
-          },
+          data:
+            type === 'mission_intro'
+              ? {
+                  title: '',
+                  text: '',
+                  room_id: parent ? parent.id : '',
+                  choices: [],
+                }
+              : {
+                  name: '',
+                  text: '',
+                  room_id: parent ? parent.id : '',
+                },
           style: { width: 150, height: 80, zIndex: 1 },
           ...(parent ? { parentNode: parent.id } : {}),
         };
@@ -111,7 +119,7 @@ export default function MissionGraph({
 
   const onNodeDragStop = useCallback(
     (event, node) => {
-      if (node.type !== 'mission_intro') return;
+      if (node.type !== 'mission_intro' && node.type !== 'npc') return;
 
       const graphNodes = reactFlowInstance.current.getNodes();
       const position = node.positionAbsolute || node.position;

--- a/game-client/src/components/MissionIntroNode.jsx
+++ b/game-client/src/components/MissionIntroNode.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Handle } from 'reactflow';
 
 export default function MissionIntroNode({ id, data }) {
-  const outputCount = data.choices?.length || 0;
   return (
     <div
       style={{
@@ -14,10 +13,12 @@ export default function MissionIntroNode({ id, data }) {
         height: '100%',
         display: 'flex',
         flexDirection: 'column',
-        justifyContent: 'space-between',
+        justifyContent: 'flex-start',
         position: 'relative',
+        gap: 4,
       }}
     >
+      <Handle type="target" position="left" />
       <strong>{data.title || 'Intro'}</strong>
       {!data.room_id && (
         <div style={{ color: 'orange', fontSize: 12 }}>⚠ Not in room</div>
@@ -25,14 +26,24 @@ export default function MissionIntroNode({ id, data }) {
       {(!data.choices || data.choices.length === 0) && (
         <div style={{ color: 'orange', fontSize: 12 }}>⚠ No outputs</div>
       )}
-      {data.choices?.map((_, idx) => (
-        <Handle
+      {data.choices?.map((choice, idx) => (
+        <div
           key={idx}
-          type="source"
-          position="bottom"
-          id={`${id}-out-${idx}`}
-          style={{ left: `${((idx + 1) / (outputCount + 1)) * 100}%` }}
-        />
+          style={{
+            position: 'relative',
+            display: 'flex',
+            alignItems: 'center',
+            fontSize: 12,
+            paddingRight: 8,
+          }}
+        >
+          <span>{choice.label || `Choice ${idx + 1}`}</span>
+          <Handle
+            type="source"
+            position="right"
+            id={`${id}-out-${idx}`}
+          />
+        </div>
       ))}
     </div>
   );

--- a/game-client/src/components/MissionIntroNode.jsx
+++ b/game-client/src/components/MissionIntroNode.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
+import { Handle } from 'reactflow';
 
-export default function MissionIntroNode({ data }) {
+export default function MissionIntroNode({ id, data }) {
+  const outputCount = data.choices?.length || 0;
   return (
     <div
       style={{
@@ -13,6 +15,7 @@ export default function MissionIntroNode({ data }) {
         display: 'flex',
         flexDirection: 'column',
         justifyContent: 'space-between',
+        position: 'relative',
       }}
     >
       <strong>{data.title || 'Intro'}</strong>
@@ -22,6 +25,15 @@ export default function MissionIntroNode({ data }) {
       {(!data.choices || data.choices.length === 0) && (
         <div style={{ color: 'orange', fontSize: 12 }}>⚠ No outputs</div>
       )}
+      {data.choices?.map((_, idx) => (
+        <Handle
+          key={idx}
+          type="source"
+          position="bottom"
+          id={`${id}-out-${idx}`}
+          style={{ left: `${((idx + 1) / (outputCount + 1)) * 100}%` }}
+        />
+      ))}
     </div>
   );
 }

--- a/game-client/src/components/NodeInspector.jsx
+++ b/game-client/src/components/NodeInspector.jsx
@@ -70,6 +70,41 @@ export default function NodeInspector({
   };
 
   if (type === 'mission_intro') {
+    const handleChoiceLabelChange = (idx, value) => {
+      const newChoices = [...(data.choices || [])];
+      newChoices[idx] = { ...newChoices[idx], label: value };
+      handleFieldChange('choices', newChoices);
+    };
+
+    const handleOutcomeTypeChange = (choiceIdx, outcomeIdx, newType) => {
+      const newChoices = [...(data.choices || [])];
+      const outcomes = [...(newChoices[choiceIdx].outcomes || [])];
+      const prev = outcomes[outcomeIdx];
+      const prevValue = prev[Object.keys(prev)[0]] || '';
+      outcomes[outcomeIdx] = { [newType]: prevValue };
+      newChoices[choiceIdx] = { ...newChoices[choiceIdx], outcomes };
+      handleFieldChange('choices', newChoices);
+    };
+
+    const handleOutcomeNodeChange = (
+      choiceIdx,
+      outcomeIdx,
+      value
+    ) => {
+      const newChoices = [...(data.choices || [])];
+      const outcomes = [...(newChoices[choiceIdx].outcomes || [])];
+      const type = Object.keys(outcomes[outcomeIdx])[0] || 'change_node';
+      outcomes[outcomeIdx] = { [type]: value };
+      newChoices[choiceIdx] = { ...newChoices[choiceIdx], outcomes };
+      handleFieldChange('choices', newChoices);
+    };
+
+    const addChoice = () => {
+      const newChoices = [...(data.choices || [])];
+      newChoices.push({ label: '', outcomes: [{ change_node: '' }] });
+      handleFieldChange('choices', newChoices);
+    };
+
     return (
       <aside style={{ padding: 8, borderLeft: '1px solid #ccc', width: 200 }}>
         <h3 style={{ marginTop: 0 }}>Intro Node</h3>
@@ -91,6 +126,49 @@ export default function NodeInspector({
             style={{ width: '100%', height: 80 }}
           />
         </label>
+        <div style={{ marginTop: 8 }}>
+          <h4 style={{ margin: '8px 0 4px' }}>Choices</h4>
+          {data.choices?.map((choice, idx) => (
+            <div key={idx} style={{ marginBottom: 8 }}>
+              <input
+                type="text"
+                value={choice.label || ''}
+                onChange={(e) => handleChoiceLabelChange(idx, e.target.value)}
+                style={{ width: '100%', marginBottom: 4 }}
+                placeholder={`Choice ${idx + 1}`}
+              />
+              {choice.outcomes?.map((outcome, oIdx) => {
+                const type = Object.keys(outcome)[0] || 'change_node';
+                return (
+                  <div
+                    key={oIdx}
+                    style={{ display: 'flex', marginBottom: 4 }}
+                  >
+                    <select
+                      value={type}
+                      onChange={(e) =>
+                        handleOutcomeTypeChange(idx, oIdx, e.target.value)
+                      }
+                      style={{ flex: 1, marginRight: 4 }}
+                    >
+                      <option value="change_node">Change Node</option>
+                    </select>
+                    <input
+                      type="text"
+                      value={outcome[type] || ''}
+                      onChange={(e) =>
+                        handleOutcomeNodeChange(idx, oIdx, e.target.value)
+                      }
+                      style={{ flex: 1 }}
+                      placeholder="Node ID"
+                    />
+                  </div>
+                );
+              })}
+            </div>
+          ))}
+          <button onClick={addChoice}>Add Choice</button>
+        </div>
         <div>Room ID: {data.room_id || '(none)'}</div>
         {!data.room_id && (
           <div style={{ color: 'orange', marginTop: 8 }}>

--- a/game-client/src/components/NodeInspector.jsx
+++ b/game-client/src/components/NodeInspector.jsx
@@ -5,6 +5,7 @@ export default function NodeInspector({
   onChange,
   mission,
   onMissionChange,
+  onAddEdge,
 }) {
   if (!selectedNode) {
     const handleMissionFieldChange = (field, value) => {
@@ -97,6 +98,9 @@ export default function NodeInspector({
       outcomes[outcomeIdx] = { [type]: value };
       newChoices[choiceIdx] = { ...newChoices[choiceIdx], outcomes };
       handleFieldChange('choices', newChoices);
+      if (type === 'change_node' && value) {
+        onAddEdge?.(id, value);
+      }
     };
 
     const addChoice = () => {
@@ -178,6 +182,38 @@ export default function NodeInspector({
         {(!data.choices || data.choices.length === 0) && (
           <div style={{ color: 'orange', marginTop: 8 }}>
             Warning: Intro node has no outputs
+          </div>
+        )}
+      </aside>
+    );
+  }
+
+  if (type === 'npc') {
+    return (
+      <aside style={{ padding: 8, borderLeft: '1px solid #ccc', width: 200 }}>
+        <h3 style={{ marginTop: 0 }}>NPC Node</h3>
+        <div style={{ marginBottom: 8 }}>ID: {id}</div>
+        <label>
+          Name:
+          <input
+            type="text"
+            value={data.name || ''}
+            onChange={(e) => handleFieldChange('name', e.target.value)}
+            style={{ width: '100%' }}
+          />
+        </label>
+        <label>
+          Text:
+          <textarea
+            value={data.text || ''}
+            onChange={(e) => handleFieldChange('text', e.target.value)}
+            style={{ width: '100%', height: 80 }}
+          />
+        </label>
+        <div>Room ID: {data.room_id || '(none)'}</div>
+        {!data.room_id && (
+          <div style={{ color: 'orange', marginTop: 8 }}>
+            Warning: NPC node is not in a room
           </div>
         )}
       </aside>

--- a/game-client/src/components/NodeLibrary.jsx
+++ b/game-client/src/components/NodeLibrary.jsx
@@ -36,6 +36,20 @@ export default function NodeLibrary({ onDragStart: onStart, onDragEnd: onEnd }) 
       >
         Mission Intro Node
       </div>
+      <div
+        style={{
+          padding: 8,
+          border: '1px solid #999',
+          borderRadius: 4,
+          cursor: 'grab',
+          marginTop: 8,
+        }}
+        onDragStart={(event) => handleDragStart(event, 'npc')}
+        onDragEnd={handleDragEnd}
+        draggable
+      >
+        NPC Node
+      </div>
     </aside>
   );
 }

--- a/game-client/src/components/NpcNode.jsx
+++ b/game-client/src/components/NpcNode.jsx
@@ -1,6 +1,11 @@
 import React from 'react';
+import { Handle, useStoreState } from 'reactflow';
 
-export default function NpcNode({ data }) {
+export default function NpcNode({ id, data }) {
+  const hasInput = useStoreState((state) =>
+    state.edges.some((e) => e.target === id)
+  );
+
   return (
     <div
       style={{
@@ -13,11 +18,14 @@ export default function NpcNode({ data }) {
         display: 'flex',
         flexDirection: 'column',
         justifyContent: 'space-between',
+        position: 'relative',
       }}
     >
+      <Handle type="target" position="top" />
       <strong>{data.name || 'NPC'}</strong>
-      {data.text && (
-        <div style={{ fontSize: 12 }}>{data.text}</div>
+      {data.text && <div style={{ fontSize: 12 }}>{data.text}</div>}
+      {!hasInput && (
+        <div style={{ color: 'orange', fontSize: 12 }}>⚠ No input</div>
       )}
     </div>
   );

--- a/game-client/src/components/NpcNode.jsx
+++ b/game-client/src/components/NpcNode.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+export default function NpcNode({ data }) {
+  return (
+    <div
+      style={{
+        background: '#fff',
+        border: '1px solid #888',
+        borderRadius: 4,
+        padding: 4,
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'space-between',
+      }}
+    >
+      <strong>{data.name || 'NPC'}</strong>
+      {data.text && (
+        <div style={{ fontSize: 12 }}>{data.text}</div>
+      )}
+    </div>
+  );
+}

--- a/game-client/src/components/NpcNode.jsx
+++ b/game-client/src/components/NpcNode.jsx
@@ -21,7 +21,7 @@ export default function NpcNode({ id, data }) {
         position: 'relative',
       }}
     >
-      <Handle type="target" position="top" />
+      <Handle type="target" position="left" />
       <strong>{data.name || 'NPC'}</strong>
       {data.text && <div style={{ fontSize: 12 }}>{data.text}</div>}
       {!hasInput && (

--- a/game-client/src/components/NpcNode.jsx
+++ b/game-client/src/components/NpcNode.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { Handle, useStoreState } from 'reactflow';
+import { Handle, useStore } from 'reactflow';
 
 export default function NpcNode({ id, data }) {
-  const hasInput = useStoreState((state) =>
+  const hasInput = useStore((state) =>
     state.edges.some((e) => e.target === id)
   );
 

--- a/game-client/src/pages/MissionEditor.jsx
+++ b/game-client/src/pages/MissionEditor.jsx
@@ -50,6 +50,19 @@ export default function MissionEditor() {
     [setNodes]
   );
 
+  const handleOutcomeConnection = useCallback(
+    (sourceId, targetId) => {
+      if (!nodes.some((n) => n.id === targetId)) return;
+      setEdges((eds) => {
+        if (eds.some((e) => e.source === sourceId && e.target === targetId)) {
+          return eds;
+        }
+        return addEdge({ source: sourceId, target: targetId }, eds);
+      });
+    },
+    [nodes, setEdges]
+  );
+
   const selectedNode =
     nodes.find((node) => node.id === selectedNodeId) || null;
 
@@ -80,6 +93,7 @@ export default function MissionEditor() {
           onChange={handleNodeUpdate}
           mission={mission}
           onMissionChange={handleMissionChange}
+          onAddEdge={handleOutcomeConnection}
         />
       </div>
     </div>

--- a/game-client/src/pages/MissionEditor.jsx
+++ b/game-client/src/pages/MissionEditor.jsx
@@ -82,7 +82,6 @@ export default function MissionEditor() {
           onMissionChange={handleMissionChange}
         />
       </div>
-      <p style={{ marginTop: 16 }}>Mission editor content coming soon.</p>
     </div>
   );
 }

--- a/game-client/src/pages/MissionEditor.jsx
+++ b/game-client/src/pages/MissionEditor.jsx
@@ -63,6 +63,15 @@ export default function MissionEditor() {
     [nodes, setEdges]
   );
 
+  const handleOutcomeDisconnection = useCallback(
+    (sourceId, targetId) => {
+      setEdges((eds) =>
+        eds.filter((e) => !(e.source === sourceId && e.target === targetId))
+      );
+    },
+    [setEdges]
+  );
+
   const selectedNode =
     nodes.find((node) => node.id === selectedNodeId) || null;
 
@@ -94,6 +103,7 @@ export default function MissionEditor() {
           mission={mission}
           onMissionChange={handleMissionChange}
           onAddEdge={handleOutcomeConnection}
+          onRemoveEdge={handleOutcomeDisconnection}
         />
       </div>
     </div>

--- a/game-client/test/navigation.test.jsx
+++ b/game-client/test/navigation.test.jsx
@@ -41,6 +41,6 @@ describe('App navigation', () => {
     expect(await screen.findByText('Main Menu')).toBeTruthy();
 
     fireEvent.click(screen.getByText('Mission Editor'));
-    expect(await screen.findByText('Mission editor content coming soon.')).toBeTruthy();
+    expect(await screen.findByText('Mission Editor')).toBeTruthy();
   });
 });

--- a/game-client/test/navigation.test.jsx
+++ b/game-client/test/navigation.test.jsx
@@ -42,5 +42,6 @@ describe('App navigation', () => {
 
     fireEvent.click(screen.getByText('Mission Editor'));
     expect(await screen.findByText('Mission Editor')).toBeTruthy();
+    expect(await screen.findByText('NPC Node')).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
- Remove placeholder text from the mission editor page
- Allow mission intro nodes to add choices with configurable outcome targeting another node
- Update navigation test for mission editor page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d61b8a8188333875eb93ccc594ea1