### PR TITLE
Align intro node outputs and remove inputs

### DIFF
--- a/game-client/src/components/MissionIntroNode.jsx
+++ b/game-client/src/components/MissionIntroNode.jsx
@@ -42,8 +42,7 @@ export default function MissionIntroNode({ id, data }) {
           <span
             style={{
               position: 'absolute',
-              left: '100%',
-              marginLeft: 4,
+              right: 0,
               top: '50%',
               transform: 'translateY(-50%)',
               whiteSpace: 'nowrap',

--- a/game-client/src/components/MissionIntroNode.jsx
+++ b/game-client/src/components/MissionIntroNode.jsx
@@ -18,7 +18,6 @@ export default function MissionIntroNode({ id, data }) {
         gap: 4,
       }}
     >
-      <Handle type="target" position="left" />
       <strong>{data.title || 'Intro'}</strong>
       {!data.room_id && (
         <div style={{ color: 'orange', fontSize: 12 }}>⚠ Not in room</div>
@@ -31,18 +30,27 @@ export default function MissionIntroNode({ id, data }) {
           key={idx}
           style={{
             position: 'relative',
-            display: 'flex',
-            alignItems: 'center',
             fontSize: 12,
-            paddingRight: 8,
+            overflow: 'visible',
           }}
         >
-          <span>{choice.label || `Choice ${idx + 1}`}</span>
           <Handle
             type="source"
             position="right"
             id={`${id}-out-${idx}`}
           />
+          <span
+            style={{
+              position: 'absolute',
+              left: '100%',
+              marginLeft: 4,
+              top: '50%',
+              transform: 'translateY(-50%)',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {choice.label || `Choice ${idx + 1}`}
+          </span>
         </div>
       ))}
     </div>

--- a/game-client/src/components/MissionIntroNode.jsx
+++ b/game-client/src/components/MissionIntroNode.jsx
@@ -32,6 +32,7 @@ export default function MissionIntroNode({ id, data }) {
             position: 'relative',
             fontSize: 12,
             overflow: 'visible',
+            width: '100%',
           }}
         >
           <Handle

--- a/game-client/test/mission-intro-node.test.jsx
+++ b/game-client/test/mission-intro-node.test.jsx
@@ -5,7 +5,7 @@ import MissionIntroNode from '../src/components/MissionIntroNode';
 import { ReactFlowProvider } from 'reactflow';
 
 describe('MissionIntroNode', () => {
-  it('renders without input handles and aligns choice labels to the right', () => {
+  it('renders without input handles and keeps choice labels inside on the right edge', () => {
     const data = { title: 'Intro', room_id: 'room-1', choices: [{ label: 'Go' }] };
     const { container, getByText } = render(
       <ReactFlowProvider>
@@ -18,7 +18,7 @@ describe('MissionIntroNode', () => {
 
     const label = getByText('Go');
     expect(label.style.position).toBe('absolute');
-    expect(label.style.left).toBe('100%');
-    expect(label.style.marginLeft).toBe('4px');
+    expect(label.style.right).toBe('0px');
+    expect(label.style.left).toBe('');
   });
 });

--- a/game-client/test/mission-intro-node.test.jsx
+++ b/game-client/test/mission-intro-node.test.jsx
@@ -14,7 +14,9 @@ describe('MissionIntroNode', () => {
     );
 
     expect(container.querySelector('.react-flow__handle-left')).toBeNull();
-    expect(container.querySelector('.react-flow__handle-right')).not.toBeNull();
+    const handle = container.querySelector('.react-flow__handle-right');
+    expect(handle).not.toBeNull();
+    expect(handle.parentElement.style.width).toBe('100%');
 
     const label = getByText('Go');
     expect(label.style.position).toBe('absolute');

--- a/game-client/test/mission-intro-node.test.jsx
+++ b/game-client/test/mission-intro-node.test.jsx
@@ -1,0 +1,24 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import MissionIntroNode from '../src/components/MissionIntroNode';
+import { ReactFlowProvider } from 'reactflow';
+
+describe('MissionIntroNode', () => {
+  it('renders without input handles and aligns choice labels to the right', () => {
+    const data = { title: 'Intro', room_id: 'room-1', choices: [{ label: 'Go' }] };
+    const { container, getByText } = render(
+      <ReactFlowProvider>
+        <MissionIntroNode id="intro-1" data={data} />
+      </ReactFlowProvider>
+    );
+
+    expect(container.querySelector('.react-flow__handle-left')).toBeNull();
+    expect(container.querySelector('.react-flow__handle-right')).not.toBeNull();
+
+    const label = getByText('Go');
+    expect(label.style.position).toBe('absolute');
+    expect(label.style.left).toBe('100%');
+    expect(label.style.marginLeft).toBe('4px');
+  });
+});


### PR DESCRIPTION
## Summary
- Remove input handles from mission intro nodes
- Position choice labels just right of their output handles
- Add tests ensuring intro nodes render no inputs and labels align correctly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e1deb8528833399af16780a659fbc