### PR TITLE
Handle resource requirements and scout rewards

### DIFF
--- a/assets/missions/whispering_corridors.json
+++ b/assets/missions/whispering_corridors.json
@@ -59,6 +59,22 @@
       ]
     },
     {
+      "id": "secret_shortcut",
+      "type": "transition",
+      "room_id": "palace_hall",
+      "title": "Secret Shortcut",
+      "text": "Behind a loose tapestry, a narrow passage leads onward.",
+      "repeatable": true,
+      "priority": 4.5,
+      "entry_conditions": [],
+      "choices": [
+        {
+          "label": "Take the secret shortcut",
+          "outcomes": [{ "move_room": "side_corridor" }]
+        }
+      ]
+    },
+    {
       "id": "collapsed_corridor",
       "type": "lock",
       "room_id": "palace_hall",

--- a/assets/players/example_player.json
+++ b/assets/players/example_player.json
@@ -94,6 +94,12 @@
         "id": "rope",
         "name": "Climbing Rope",
         "quantity": 1
+      },
+      {
+        "id": "trail_rations",
+        "name": "Trail Rations",
+        "quantity": 1,
+        "tags": ["food"]
       }
     ],
     "cards": [

--- a/game-client/src/pages/MissionPlayer.jsx
+++ b/game-client/src/pages/MissionPlayer.jsx
@@ -15,6 +15,16 @@ export default function MissionPlayer({ player }) {
   const [currentRoomId, setCurrentRoomId] = useState(mission ? mission.start_room_id : null);
   const [ended, setEnded] = useState(false);
   const [currentNodeIndex, setCurrentNodeIndex] = useState(0);
+  const [flags, setFlags] = useState({});
+  const [infos, setInfos] = useState([]);
+  const [visibleNodes, setVisibleNodes] = useState(() => {
+    const initial = {};
+    mission.rooms.forEach((r) => {
+      initial[r.id] = [...(r.auto_nodes || [])];
+    });
+    return initial;
+  });
+  const [message, setMessage] = useState('');
 
   if (!mission) {
     return (
@@ -28,8 +38,21 @@ export default function MissionPlayer({ player }) {
   }
 
   const room = mission.rooms.find((r) => r.id === currentRoomId);
-  const nodes =
-    room?.auto_nodes.map((id) => mission.nodes.find((n) => n.id === id)).filter(Boolean) || [];
+
+  function checkEntryConditions(n) {
+    return (n.entry_conditions || []).every((cond) => {
+      if (cond.flag_not_set) return !flags[cond.flag_not_set];
+      if (cond.flag_set) return !!flags[cond.flag_set];
+      return true;
+    });
+  }
+
+  const nodeIds = visibleNodes[currentRoomId] || [];
+  const nodes = nodeIds
+    .map((id) => mission.nodes.find((n) => n.id === id))
+    .filter(Boolean)
+    .filter((n) => checkEntryConditions(n))
+    .sort((a, b) => (b.priority || 0) - (a.priority || 0));
   const node = nodes[currentNodeIndex];
 
   useEffect(() => {
@@ -53,23 +76,86 @@ export default function MissionPlayer({ player }) {
     if (outcome.end_mission) {
       setEnded(true);
     }
+    if (outcome.set_flag) {
+      setFlags((f) => ({ ...f, [outcome.set_flag]: true }));
+      return 'You help the scout.';
+    }
+    if (outcome.grant_info) {
+      setInfos((i) => [...i, outcome.grant_info]);
+      return 'He shares a hint.';
+    }
+    if (outcome.reveal_node) {
+      const nodeToReveal = mission.nodes.find((n) => n.id === outcome.reveal_node);
+      if (nodeToReveal) {
+        setVisibleNodes((prev) => {
+          const updated = { ...prev };
+          const arr = updated[nodeToReveal.room_id] || [];
+          if (!arr.includes(nodeToReveal.id)) {
+            updated[nodeToReveal.room_id] = [...arr, nodeToReveal.id];
+          }
+          return updated;
+        });
+      }
+      if (outcome.reveal_node === 'secret_shortcut') {
+        return 'A secret shortcut is revealed.';
+      }
+    }
+    return '';
   }
 
   function advanceNode() {
+    setMessage('');
     setCurrentNodeIndex((idx) => idx + 1);
   }
 
+  function requirementsMet(choice) {
+    if (!choice.requirements) return true;
+    return choice.requirements.every((req) => {
+      if (req.has_item_tag) {
+        return player.inventory.items?.some((item) =>
+          item.tags?.includes(req.has_item_tag)
+        );
+      }
+      return true;
+    });
+  }
+
   function handleChoice(choice, node) {
+    setMessage('');
+    if (!requirementsMet(choice)) {
+      const tag = choice.requirements.find((r) => r.has_item_tag)?.has_item_tag;
+      if (tag === 'food') {
+        setMessage("You don't have food to offer.");
+      } else {
+        setMessage("You don't have the required item.");
+      }
+      return;
+    }
     const outcomes = choice.outcomes || choice.success_outcomes || [];
     let moved = false;
     let finished = false;
+    const messages = [];
     outcomes.forEach((o) => {
       if (o.move_room) moved = true;
       if (o.end_mission) finished = true;
-      handleOutcome(o);
+      const msg = handleOutcome(o);
+      if (msg) messages.push(msg);
     });
+    if (messages.length) {
+      setMessage(messages.join(' '));
+    }
     if (!moved && !finished && !node.repeatable) {
-      advanceNode();
+      const removesNode = outcomes.some(
+        (o) =>
+          o.set_flag &&
+          node.entry_conditions?.some((c) => c.flag_not_set === o.set_flag)
+      );
+      if (removesNode) {
+        setMessage('');
+        setCurrentNodeIndex((idx) => idx);
+      } else {
+        advanceNode();
+      }
     }
   }
 
@@ -77,11 +163,16 @@ export default function MissionPlayer({ player }) {
     const outcomes = victory ? node.on_victory || [] : node.on_defeat || [];
     let moved = false;
     let finished = false;
+    const messages = [];
     outcomes.forEach((o) => {
       if (o.move_room) moved = true;
       if (o.end_mission) finished = true;
-      handleOutcome(o);
+      const msg = handleOutcome(o);
+      if (msg) messages.push(msg);
     });
+    if (messages.length) {
+      setMessage(messages.join(' '));
+    }
     if (!moved && !finished && !node.repeatable) {
       advanceNode();
     }
@@ -129,6 +220,7 @@ export default function MissionPlayer({ player }) {
               </button>
             ))
           )}
+          {message && <p style={{ marginTop: 16 }}>{message}</p>}
         </div>
       )}
     </div>

--- a/game-client/test/mission-results.test.jsx
+++ b/game-client/test/mission-results.test.jsx
@@ -40,6 +40,10 @@ describe('Mission results', () => {
       fireEvent.click(await screen.findByText('Slash'));
     }
 
+    // vault_loot -> Collect
+    await screen.findByText('Guard Satchel');
+    fireEvent.click(screen.getByText('Collect'));
+
     // to_vault_antechamber -> Proceed
     await screen.findByText('Descend the stairs');
     fireEvent.click(screen.getByText('Proceed'));

--- a/game-client/test/wounded-scout.test.jsx
+++ b/game-client/test/wounded-scout.test.jsx
@@ -1,0 +1,59 @@
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import App from '../src/App.jsx';
+import examplePlayer from '../../assets/players/example_player.json';
+
+describe('Wounded Scout event', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.reject(new Error('network error'))));
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    localStorage.clear();
+    cleanup();
+  });
+
+  it('warns when player lacks food', async () => {
+    const noFoodPlayer = {
+      ...examplePlayer,
+      inventory: {
+        ...examplePlayer.inventory,
+        items: examplePlayer.inventory.items.filter(
+          (i) => !(i.tags && i.tags.includes('food'))
+        ),
+      },
+    };
+    localStorage.setItem('player', JSON.stringify(noFoodPlayer));
+
+    render(
+      <MemoryRouter initialEntries={['/missions/whispering_corridors']}>
+        <App />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByText('Continue'));
+    await screen.findAllByText('Wounded Scout');
+    const [offerBtn1] = screen.getAllByText('Offer food');
+    fireEvent.click(offerBtn1);
+    expect(await screen.findByText("You don't have food to offer.")).toBeTruthy();
+  });
+
+  it('reveals secret shortcut when food is offered', async () => {
+    localStorage.setItem('player', JSON.stringify(examplePlayer));
+
+    render(
+      <MemoryRouter initialEntries={['/missions/whispering_corridors']}>
+        <App />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByText('Continue'));
+    await screen.findAllByText('Wounded Scout');
+    const [offerBtn2] = screen.getAllByText('Offer food');
+    fireEvent.click(offerBtn2);
+    expect(await screen.findByText('Take the secret shortcut')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- Add trail rations to example player inventory for food-tag test cases
- Extend mission engine with item requirement checks, flag setting, and node reveal support
- Include secret shortcut node and updated mission flow for Wounded Scout event
- Cover scout interaction and revealed loot with new and updated tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0130e09008333bd48245f5979100d