### PR TITLE
feat: show base HP on character cards

### DIFF
--- a/game-client/src/components/Card.jsx
+++ b/game-client/src/components/Card.jsx
@@ -37,11 +37,13 @@ export default function Card({ card }) {
           .filter(([key]) => card.stats?.[key] !== undefined)
           .map(([key, label]) => `${label} ${card.stats[key]}`)
           .join(', ');
+        const baseHp = card.stats?.end ? card.stats.end * 2 : 20;
         return (
           <>
             <div>Class: {card.class}</div>
             <div>Race: {card.race}</div>
             {stats && <div>Stats: {stats}</div>}
+            <div>Base HP: {baseHp}</div>
             {card.abilities && <div>Abilities: {card.abilities.join(', ')}</div>}
             {card.primary_attack && <div>Primary: {card.primary_attack}</div>}
           </>


### PR DESCRIPTION
## Summary
- show base HP for character cards based on END stat

## Testing
- `cd game-client && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a801bef6908333ae9d20a00ff70bd9